### PR TITLE
Add support for unicode normalization and supplementary planes.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -19,6 +19,7 @@ const libTarget = Object.assign(
   buildTools.config.LIB_TARGET,
   {
     name: "lib-es2015",
+    typeRoots: ["custom-typings", "../typings/globals", "../typings/modules", "../node_modules/@types"],
     typescript: {
       compilerOptions: {
         skipLibCheck: true,
@@ -37,6 +38,7 @@ const es5Target = Object.assign(
   buildTools.config.LIB_TARGET,
   {
     name: "lib-es5",
+    typeRoots: ["custom-typings", "../typings/globals", "../typings/modules", "../node_modules/@types"],
     typescript: {
       compilerOptions: {
         skipLibCheck: true,
@@ -56,6 +58,7 @@ const libTestTarget = Object.assign(
   {
     name: "lib-test",
     scripts: ["test/**/*.ts", "lib/**/*.ts"],
+    typeRoots: ["custom-typings", "../typings/globals", "../typings/modules", "../node_modules/@types"],
     typescript: {
       compilerOptions: {
         skipLibCheck: true,

--- a/package.json
+++ b/package.json
@@ -28,9 +28,12 @@
   "license": "MIT",
   "dependencies": {
     "incident": "^1.1.1",
-    "lodash": "^4.17.4"
+    "lodash": "^4.17.4",
+    "punycode": "^2.1.0",
+    "unorm": "^1.4.1"
   },
   "devDependencies": {
+    "@types/unorm": "^1.3.27",
     "chai": "^3.5.0",
     "demurgos-web-build-tools": "0.13.0-beta.5",
     "gulp": "github:gulpjs/gulp#4.0",

--- a/src/custom-typings/punycode/punycode.d.ts
+++ b/src/custom-typings/punycode/punycode.d.ts
@@ -1,0 +1,134 @@
+/* tslint:disable:no-namespace no-mergeable-namespace */
+
+declare module "punycode" {
+  /**
+   * Converts a Punycode string of ASCII-only symbols to a string of Unicode
+   * symbols.
+   *
+   * ```js
+   * // decode domain name parts
+   * punycode.decode('maana-pta'); // 'mañana'
+   * punycode.decode('--dqo34k'); // '☃-⌘'
+   * ```
+   *
+   * @param {string} input The Punycode string of ASCII-only symbols.
+   * @returns {string} The resulting string of Unicode symbols.
+   */
+  export function decode(input: string): string;
+
+  /**
+   * Converts a string of Unicode symbols (e.g. a domain name label) to a
+   * Punycode string of ASCII symbols.
+   *
+   * ```js
+   * // encode domain name parts
+   * punycode.encode('mañana'); // 'maana-pta'
+   * punycode.encode('☃-⌘'); // '--dqo34k'
+   * ```
+   *
+   * @param {string} input The string of Unicode symbols.
+   * @returns {string} The resulting Punycode string of ASCII-only symbols.
+   */
+  export function encode(input: string): string;
+
+  /**
+   * Converts a Punycode string representing a domain name or an email address
+   * to Unicode. Only the Punycoded parts of the input will be converted,
+   * i.e. it doesn’t matter if you call it on a string that has already been
+   * converted to Unicode.
+   *
+   * ```js
+   * // decode domain names
+   * punycode.toUnicode('xn--maana-pta.com');
+   * // → 'mañana.com'
+   * punycode.toUnicode('xn----dqo34k.com');
+   * // → '☃-⌘.com'
+   *
+   * // decode email addresses
+   * punycode.toUnicode('джумла@xn--p-8sbkgc5ag7bhce.xn--ba-lmcq');
+   * // → 'джумла@джpумлатест.bрфa'
+   * ```
+   *
+   * @param {string} input The Punycoded domain name or email address to
+   * convert to Unicode.
+   * @returns {string} The Unicode representation of the given Punycode
+   * string.
+   */
+  export function toUnicode(input: string): string;
+
+  /**
+   * Converts a lowercased Unicode string representing a domain name or an
+   * email address to Punycode. Only the non-ASCII parts of the input will be
+   * converted, i.e. it doesn’t matter if you call it with a domain that’s
+   * already in ASCII.
+   *
+   * ```js
+   * // encode domain names
+   * punycode.toASCII('mañana.com');
+   * // → 'xn--maana-pta.com'
+   * punycode.toASCII('☃-⌘.com');
+   * // → 'xn----dqo34k.com'
+   *
+   * // encode email addresses
+   * punycode.toASCII('джумла@джpумлатест.bрфa');
+   * // → 'джумла@xn--p-8sbkgc5ag7bhce.xn--ba-lmcq'
+   * ```
+   *
+   * @param {string} input The domain name or email address to convert, as a
+   * Unicode string.
+   * @returns {string} The Punycode representation of the given domain name or
+   * email address.
+   */
+  export function toASCII(input: string): string;
+
+  /**
+   * An object of methods to convert from JavaScript's internal character
+   * representation (UCS-2) to Unicode code points, and back.
+   *
+   * @see <https://mathiasbynens.be/notes/javascript-encoding>
+   */
+  export namespace ucs2 {
+    /**
+     * Creates an array containing the numeric code points of each Unicode
+     * character in the string. While JavaScript uses UCS-2 internally,
+     * this function will convert a pair of surrogate halves (each of which
+     * UCS-2 exposes as separate characters) into a single code point,
+     * matching UTF-16.
+     *
+     * ```js
+     * punycode.ucs2.decode('abc');
+     * // → [0x61, 0x62, 0x63]
+     * // surrogate pair for U+1D306 TETRAGRAM FOR CENTRE:
+     * punycode.ucs2.decode('\uD834\uDF06');
+     * // → [0x1D306]
+     * ```
+     *
+     * @see `punycode.ucs2.encode`
+     * @see <https://mathiasbynens.be/notes/javascript-encoding>
+     * @param {string} string The Unicode input string (UCS-2).
+     * @returns {number[]} The new array of code points.
+     */
+    export function decode(string: string): number[];
+
+    /**
+     * Creates a string based on an array of numeric code point values.
+     *
+     * ```js
+     * punycode.ucs2.encode([0x61, 0x62, 0x63]);
+     * // → 'abc'
+     * punycode.ucs2.encode([0x1D306]);
+     * // → '\uD834\uDF06'
+     * ```
+     *
+     * @see `punycode.ucs2.decode`
+     * @param {number[]} codePoints The array of numeric code points.
+     * @returns {string} The new Unicode string (UCS-2).
+     */
+    export function encode(codePoints: number[]): string;
+  }
+
+  /**
+   * A string representing the current Punycode.js version number.
+   */
+  export const version: string;
+}

--- a/src/lib/errors/min-length-error.ts
+++ b/src/lib/errors/min-length-error.ts
@@ -4,14 +4,14 @@ import {KryoError} from "./kryo-error";
  * Interface for the `.data` property of `MinLengthError`.
  */
 export interface MinLengthErrorData {
-  string: string;
+  string: string | any[];
   minLength: number;
 }
 
 export class MinLengthError extends KryoError<MinLengthErrorData> {
-  constructor(string: string, minLength: number) {
+  constructor(string: string | any[], minLength: number) {
     super(
-      "MinLengthError",
+      "MaxLengthError",
       {string: string, minLength: minLength},
       `Expected string length (${string.length}) to be greater than or equal to ${minLength}`
     );

--- a/src/lib/string.spec.ts
+++ b/src/lib/string.spec.ts
@@ -1,32 +1,83 @@
+import {assert} from "chai";
 import {runTests, TypedValue} from "../test/test";
 import {StringType} from "./string";
 
 describe("StringType", function () {
-  const type: StringType = new StringType();
+  describe("basic support", function() {
+    const type: StringType = new StringType();
 
-  const items: TypedValue[] = [
-    // Valid items
-    {name: '""', value: "", valid: true},
-    {name: '"Hello World!"', value: "Hello World!", valid: true},
-    {name: "Drop the bass", value: "ԂЯØǷ Łƕ੬ ɃɅϨϞ", valid: true},
-    // Invalid items
-    {name: 'new String("stringObject")', value: new String("stringObject"), valid: false},
-    {name: "0.5", value: 0.5, valid: false},
-    {name: "0.0001", value: 0.0001, valid: false},
-    {name: "Infinity", value: Infinity, valid: false},
-    {name: "-Infinity", value: -Infinity, valid: false},
-    {name: "NaN", value: NaN, valid: false},
-    {name: "undefined", value: undefined, valid: false},
-    {name: "null", value: null, valid: false},
-    {name: "true", value: true, valid: false},
-    {name: "false", value: false, valid: false},
-    {name: "[]", value: [], valid: false},
-    {name: "{}", value: {}, valid: false},
-    {name: "new Date()", value: new Date(), valid: false},
-    {name: "/regex/", value: /regex/, valid: false}
-  ];
+    const items: TypedValue[] = [
+      // Valid items
+      {name: '""', value: "", valid: true},
+      {name: '"Hello World!"', value: "Hello World!", valid: true},
+      {name: "Drop the bass", value: "ԂЯØǷ Łƕ੬ ɃɅϨϞ", valid: true},
+      // Invalid items
+      {name: 'new String("stringObject")', value: new String("stringObject"), valid: false},
+      {name: "0.5", value: 0.5, valid: false},
+      {name: "0.0001", value: 0.0001, valid: false},
+      {name: "Infinity", value: Infinity, valid: false},
+      {name: "-Infinity", value: -Infinity, valid: false},
+      {name: "NaN", value: NaN, valid: false},
+      {name: "undefined", value: undefined, valid: false},
+      {name: "null", value: null, valid: false},
+      {name: "true", value: true, valid: false},
+      {name: "false", value: false, valid: false},
+      {name: "[]", value: [], valid: false},
+      {name: "{}", value: {}, valid: false},
+      {name: "new Date()", value: new Date(), valid: false},
+      {name: "/regex/", value: /regex/, valid: false}
+    ];
 
-  runTests(type, items);
+    runTests(type, items);
+  });
+
+  describe("unicode support", function() {
+    const simpleString: StringType = new StringType({
+      unicodeSupplementaryPlanes: false,
+      unicodeNormalization: false,
+      maxLength: 1
+    });
+
+    const unicodeString: StringType = new StringType({
+      unicodeSupplementaryPlanes: true,
+      unicodeNormalization: true,
+      maxLength: 1
+    });
+
+    const simpleStringItems: TypedValue[] = [
+      // Valid items
+      {name: '"" with simple string type', value: "", valid: true},
+      {name: '"a" with simple string type', value: "a", valid: true},
+      {name: '"∑" with simple string type', value: "∑", valid: true},
+      {name: '"𝄞" with simple string type', value: "𝄞", valid: false}
+    ];
+
+    const unicodeStringItems: TypedValue[] = [
+      // Valid items
+      {name: '"" with unicode string type', value: "", valid: true},
+      {name: '"a" with unicode string type', value: "a", valid: true},
+      {name: '"∑" with unicode string type', value: "∑", valid: true},
+      {name: '"𝄞" with unicode string type', value: "𝄞", valid: true}
+    ];
+
+    runTests(simpleString, simpleStringItems);
+    runTests(unicodeString, unicodeStringItems);
+
+    it("NFC normalization of then ångström symbol Å", function() {
+      const inputAngstrom: string = "\u212b";
+      // This should pass with the maxLength limit because of normalization
+      const inputNfdAngstrom: string = "\u0041\u030a";
+      const inputNfcAngstrom: string = "\u00c5";
+
+      const angstrom: string = unicodeString.readSync("json-doc", inputAngstrom);
+      const nfdAngstrom: string = unicodeString.readSync("json-doc", inputNfdAngstrom);
+      const nfcAngstrom: string = unicodeString.readSync("json-doc", inputNfcAngstrom);
+
+      assert.equal(nfcAngstrom, "\u00c5", "NFC normalization is not preserved");
+      assert.equal(angstrom, "\u00c5", "Standard ångström symbol is not normalized");
+      assert.equal(nfdAngstrom, "\u00c5", "NFD ångström is not normalized to NFC");
+    });
+  });
 
   //
   // runTestSync(type, falsyItems);


### PR DESCRIPTION
This commit adds two dependencies to support unicode: unorm and punycode.
It also fixes a bug with the `readSync` method of StringType.

Closes #7 
