### PR TITLE
Add `rename` option to `DocumentType`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,13 @@
 # Next
 
+- **[Feature]** Add the `rename` option to `DocumentType`. This allows to rename
+  the keys of the document similarly to the values of `SimpleEnumType`.
 - **[Internal]** Fix documentation generation with typedoc
+- **[Internal]** Improve support for the tests checking the output of `.write`
 
 # 0.5.0-alpha.3
 
-- **[Minor]** Add support for the `"qs"` format for [the `qs` package][npm-qs] (used by [`express`][npm-express])
+- **[Feature]** Add support for the `"qs"` format for [the `qs` package][npm-qs] (used by [`express`][npm-express])
 - **[Internal]** Create CHANGELOG.md
 
 [npm-express]:https://www.npmjs.com/package/expess

--- a/src/test/types/array.spec.ts
+++ b/src/test/types/array.spec.ts
@@ -12,22 +12,22 @@ describe("ArrayType", function () {
     {
       value: [],
       valid: true,
-      serialized: {
-        json: {canonical: []}
+      output: {
+        json: []
       }
     },
     {
       value: [1],
       valid: true,
-      serialized: {
-        json: {canonical: [1]}
+      output: {
+        json: [1]
       }
     },
     {
       value: [2, 3],
       valid: true,
-      serialized: {
-        json: {canonical: [2, 3]}
+      output: {
+        json: [2, 3]
       }
     },
     {

--- a/src/test/types/date.spec.ts
+++ b/src/test/types/date.spec.ts
@@ -10,14 +10,18 @@ describe("DateType", function () {
       name: "new Date(0)",
       value: new Date(0),
       valid: true,
-      serialized: {
-        json: {
-          canonical: "1970-01-01T00:00:00.000Z",
-          values: [
-            {value: 0, valid: true},
-            {value: null, valid: false}
-          ]
-        }
+      output: {
+        json: "1970-01-01T00:00:00.000Z"
+      },
+      inputs: {
+        json: [
+          0
+        ]
+      },
+      invalidInputs: {
+        json: [
+          null
+        ]
       }
     },
     {name: 'new Date("1247-05-18T19:40:08.418Z")', value: new Date("1247-05-18T19:40:08.418Z"), valid: true},

--- a/src/test/types/document.spec.ts
+++ b/src/test/types/document.spec.ts
@@ -1,9 +1,10 @@
+import {CaseStyle} from "../../lib/helpers/rename";
 import {DateType} from "../../lib/types/date";
 import {DocumentType} from "../../lib/types/document";
 import {Int32Type} from "../../lib/types/int32";
 import {runTests, TypedValue} from "../helpers/test";
 
-describe("DocumentType", function () {
+describe("Document", function () {
   const documentType: DocumentType<any> = new DocumentType({
     ignoreExtraKeys: true,
     properties: {
@@ -40,8 +41,8 @@ describe("DocumentType", function () {
         }
       },
       valid: true,
-      serialized: {
-        json: {canonical: {dateProp: "1970-01-01T00:00:00.000Z", optIntProp: 50, nestedDoc: {id: 10}}}
+      output: {
+        json: {dateProp: "1970-01-01T00:00:00.000Z", optIntProp: 50, nestedDoc: {id: 10}}
       }
     },
 
@@ -63,4 +64,58 @@ describe("DocumentType", function () {
   ];
 
   runTests(documentType, items);
+});
+
+describe("Document: rename", function () {
+  interface Rect {
+    xMin: number;
+    xMax: number;
+    yMin: number;
+    yMax: number;
+  }
+
+  const type: DocumentType<Rect> = new DocumentType<Rect>({
+    properties: {
+      xMin: {type: new Int32Type()},
+      xMax: {type: new Int32Type()},
+      yMin: {type: new Int32Type()},
+      yMax: {type: new Int32Type()}
+    },
+    rename: CaseStyle.KebabCase
+  });
+
+  const items: TypedValue[] = [
+    {
+      name: "Rect {xMin: 0, xMax: 10, yMin: 20, yMax: 30}",
+      value: <Rect> {
+        xMin: 0,
+        xMax: 10,
+        yMin: 20,
+        yMax: 30
+      },
+      valid: true,
+      output: {
+        bson: {
+          "x-min": 0,
+          "x-max": 10,
+          "y-min": 20,
+          "y-max": 30
+        },
+        json: {
+          "x-min": 0,
+          "x-max": 10,
+          "y-min": 20,
+          "y-max": 30
+        },
+        qs: {
+          "x-min": "0",
+          "x-max": "10",
+          "y-min": "20",
+          "y-max": "30"
+        }
+      }
+    }
+  ];
+
+  runTests(type, items);
 });

--- a/src/test/types/float64.spec.ts
+++ b/src/test/types/float64.spec.ts
@@ -9,13 +9,8 @@ describe("Float64Type", function () {
       name: "0",
       value: 0,
       valid: true,
-      serialized: {
-        "json-doc": {
-          canonical: 0,
-          values: [
-            {value: 0, valid: true}
-          ]
-        }
+      output: {
+        json: 0
       }
     },
     {name: "1", value: 1, valid: true},

--- a/src/test/types/simple-enum.spec.ts
+++ b/src/test/types/simple-enum.spec.ts
@@ -16,48 +16,48 @@ describe("SimpleEnum", function () {
       name: "Color.Red",
       value: Color.Red,
       valid: true,
-      serialized: {
-        json: {canonical: "Red"}
+      output: {
+        json: "Red"
       }
     },
     {
       name: "Color.Green",
       value: Color.Green,
       valid: true,
-      serialized: {
-        json: {canonical: "Green"}
+      output: {
+        json: "Green"
       }
     },
     {
       name: "Color.Blue",
       value: Color.Blue,
       valid: true,
-      serialized: {
-        json: {canonical: "Blue"}
+      output: {
+        json: "Blue"
       }
     },
     {
       name: "0",
       value: 0,
       valid: true,
-      serialized: {
-        json: {canonical: "Red"}
+      output: {
+        json: "Red"
       }
     },
     {
       name: "1",
       value: 1,
       valid: true,
-      serialized: {
-        json: {canonical: "Green"}
+      output: {
+        json: "Green"
       }
     },
     {
       name: "2",
       value: 2,
       valid: true,
-      serialized: {
-        json: {canonical: "Blue"}
+      output: {
+        json: "Blue"
       }
     },
 
@@ -81,7 +81,7 @@ describe("SimpleEnum", function () {
   runTests(type, items);
 });
 
-describe("SimpleEnum#rename", function () {
+describe("SimpleEnum: rename", function () {
   enum Node {
     Expression,
     BinaryOperator,
@@ -95,48 +95,60 @@ describe("SimpleEnum#rename", function () {
       name: "Node.Expression",
       value: Node.Expression,
       valid: true,
-      serialized: {
-        json: {canonical: "expression"}
+      output: {
+        bson: "expression",
+        json: "expression",
+        qs: "expression"
       }
     },
     {
       name: "Node.BinaryOperator",
       value: Node.BinaryOperator,
       valid: true,
-      serialized: {
-        json: {canonical: "binary-operator"}
+      output: {
+        bson: "binary-operator",
+        json: "binary-operator",
+        qs: "binary-operator"
       }
     },
     {
       name: "Node.BlockStatement",
       value: Node.BlockStatement,
       valid: true,
-      serialized: {
-        json: {canonical: "block-statement"}
+      output: {
+        bson: "block-statement",
+        json: "block-statement",
+        qs: "block-statement"
       }
     },
     {
       name: "0",
       value: 0,
       valid: true,
-      serialized: {
-        json: {canonical: "expression"}
+      output: {
+        bson: "expression",
+        json: "expression",
+        qs: "expression"
       }
     },
     {
       name: "1",
       value: 1,
       valid: true,
-      serialized: {
-        json: {canonical: "binary-operator"}
+      output: {
+        bson: "binary-operator",
+        json: "binary-operator",
+        qs: "binary-operator"
       }
     },
     {
       name: "2",
       value: 2,
       valid: true,
-      serialized: {
-        json: {canonical: "block-statement"}
+      output: {
+        bson: "block-statement",
+        json: "block-statement",
+        qs: "block-statement"
       }
     }
   ];


### PR DESCRIPTION
This option allows to rename the keys of the output document (produced by `.write`) by changing the case style of the keys. This is similar to the `rename` option of `SimpleEnumType`.