### PR TITLE
Fix the constraints for `SerializableType` generics.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,11 @@
 
 - **[Feature]** Add the `rename` option to `DocumentType`. This allows to rename
   the keys of the document similarly to the values of `SimpleEnumType`.
+- **[Patch]** Fix the constraints for `SerializableType` generics.
+  `Output` should extend `Input`. This restores the order `T`, `Format`,`Input`, `Output`.
 - **[Internal]** Fix documentation generation with typedoc
 - **[Internal]** Improve support for the tests checking the output of `.write`
+- **[Internal]** Drop `lodash` dependency
 
 # 0.5.0-alpha.3
 

--- a/src/lib/interfaces.ts
+++ b/src/lib/interfaces.ts
@@ -7,16 +7,16 @@ export interface Type<T> {
   toJSON(): any;
 }
 
-export interface SerializableType<T, FormatName extends string, Output, Input extends Output> extends Type<T> {
+export interface SerializableType<T, FormatName extends string, Input, Output extends Input> extends Type<T> {
   readTrusted (format: FormatName, serialized: Output): T;
   read (format: FormatName, serialized: Input): T;
   write (format: FormatName, val: T): Output;
 }
 
-export interface VersionedType<T, Output, Input extends Output, Diff>
-  extends SerializableType<T, "json", Output, Input> {
+export interface VersionedType<T, Input, Output extends Input, Diff>
+  extends SerializableType<T, "json", Input, Output> {
   /**
-   * Returns null if both values are equivalent, otherwise a diff representing the change from
+   * Returns undefined if both values are equivalent, otherwise a diff representing the change from
    * oldVal to newVal.
    *
    * @param oldVal The old value

--- a/src/lib/types/array.ts
+++ b/src/lib/types/array.ts
@@ -29,9 +29,9 @@ export interface Options<T, Output, Input extends Output, Diff> {
 }
 
 export class ArrayType<T>
-  implements VersionedType<T[], json.Output, json.Input, Diff>,
-    SerializableType<T[], "bson", bson.Output, bson.Input>,
-    SerializableType<T[], "qs", qs.Output, qs.Input> {
+  implements VersionedType<T[], json.Input, json.Output, Diff>,
+    SerializableType<T[], "bson", bson.Input, bson.Output>,
+    SerializableType<T[], "qs", qs.Input, qs.Output> {
   readonly name: Name = name;
   readonly itemType: VersionedType<T, any, any, any>;
   readonly maxLength: number;

--- a/src/lib/types/boolean.ts
+++ b/src/lib/types/boolean.ts
@@ -21,8 +21,8 @@ export type Diff = boolean;
 
 export class BooleanType
   implements VersionedType<T, json.Input, json.Output, Diff>,
-    SerializableType<T, "bson", bson.Output, bson.Input>,
-    SerializableType<T, "qs", qs.Output, qs.Input> {
+    SerializableType<T, "bson", bson.Input, bson.Output>,
+    SerializableType<T, "qs", qs.Input, qs.Output> {
   readonly name: Name = name;
 
   toJSON(): undefined {

--- a/src/lib/types/codepoint-string.ts
+++ b/src/lib/types/codepoint-string.ts
@@ -84,8 +84,8 @@ export interface Options {
 
 export class CodepointStringType
   implements VersionedType<T, json.Input, json.Output, Diff>,
-    SerializableType<T, "bson", bson.Output, bson.Input>,
-    SerializableType<T, "qs", qs.Output, qs.Input> {
+    SerializableType<T, "bson", bson.Input, bson.Output>,
+    SerializableType<T, "qs", qs.Input, qs.Output> {
   static fromJSON(options: json.Type): CodepointStringType {
     const resolvedOptions: Options = {
       normalization: options.normalization === "none" ? Normalization.None : Normalization.Nfc,

--- a/src/lib/types/date.ts
+++ b/src/lib/types/date.ts
@@ -25,8 +25,8 @@ export type Diff = number;
 
 export class DateType
   implements VersionedType<T, json.Input, json.Output, Diff>,
-    SerializableType<T, "bson", bson.Output, bson.Input>,
-    SerializableType<T, "qs", qs.Output, qs.Input> {
+    SerializableType<T, "bson", bson.Input, bson.Output>,
+    SerializableType<T, "qs", qs.Input, qs.Output> {
   readonly name: Name = name;
 
   toJSON(): json.Type {

--- a/src/lib/types/document.ts
+++ b/src/lib/types/document.ts
@@ -104,8 +104,8 @@ function diffSets<T>(reference: Iterable<T>, values: Iterable<T>): DiffSetsResul
 
 export class DocumentType<T extends {}>
   implements VersionedType<T, json.Input, json.Output, Diff>,
-    SerializableType<T, "bson", bson.Output, bson.Input>,
-    SerializableType<T, "qs", qs.Output, qs.Input> {
+    SerializableType<T, "bson", bson.Input, bson.Output>,
+    SerializableType<T, "qs", qs.Input, qs.Output> {
   static fromJSON(options: json.Type): DocumentType<{}> {
     throw NotImplementedError.create("DocumentType.fromJSON");
   }

--- a/src/lib/types/float64.ts
+++ b/src/lib/types/float64.ts
@@ -32,8 +32,8 @@ export interface Options {
 
 export class Float64Type
   implements VersionedType<T, json.Input, json.Output, Diff>,
-    SerializableType<T, "bson", bson.Output, bson.Input>,
-    SerializableType<T, "qs", qs.Output, qs.Input> {
+    SerializableType<T, "bson", bson.Input, bson.Output>,
+    SerializableType<T, "qs", qs.Input, qs.Output> {
   static fromJSON(options: json.Type): Float64Type {
     return new Float64Type(options);
   }

--- a/src/lib/types/int32.ts
+++ b/src/lib/types/int32.ts
@@ -25,8 +25,8 @@ export type Diff = number;
 
 export class Int32Type
   implements VersionedType<T, json.Input, json.Output, Diff>,
-    SerializableType<T, "bson", bson.Output, bson.Input>,
-    SerializableType<T, "qs", qs.Output, qs.Input> {
+    SerializableType<T, "bson", bson.Input, bson.Output>,
+    SerializableType<T, "qs", qs.Input, qs.Output> {
   static fromJSON(options: json.Type): Int32Type {
     return new Int32Type();
   }

--- a/src/lib/types/null.ts
+++ b/src/lib/types/null.ts
@@ -24,8 +24,8 @@ export type Diff = undefined;
 
 export class NullType
   implements VersionedType<T, json.Input, json.Output, Diff>,
-    SerializableType<T, "bson", bson.Output, bson.Input>,
-    SerializableType<T, "qs", qs.Output, qs.Input> {
+    SerializableType<T, "bson", bson.Input, bson.Output>,
+    SerializableType<T, "qs", qs.Input, qs.Output> {
   readonly name: Name = name;
 
   toJSON(): json.Type {

--- a/src/lib/types/simple-enum.ts
+++ b/src/lib/types/simple-enum.ts
@@ -60,8 +60,8 @@ export interface Options<E extends number> {
  */
 export class SimpleEnumType<E extends number>
   implements VersionedType<E, json.Input, json.Output, Diff>,
-    SerializableType<E, "bson", bson.Output, bson.Input>,
-    SerializableType<E, "qs", qs.Output, qs.Input> {
+    SerializableType<E, "bson", bson.Input, bson.Output>,
+    SerializableType<E, "qs", qs.Input, qs.Output> {
   static fromJSON(): SimpleEnumType<any> {
     throw NotImplementedError.create("SimpleEnumType.fromJSON");
   }

--- a/src/lib/types/ucs2-string.ts
+++ b/src/lib/types/ucs2-string.ts
@@ -114,8 +114,8 @@ export interface Options {
  */
 export class Ucs2StringType
   implements VersionedType<T, json.Input, json.Output, Diff>,
-    SerializableType<T, "bson", bson.Output, bson.Input>,
-    SerializableType<T, "qs", qs.Output, qs.Input> {
+    SerializableType<T, "bson", bson.Input, bson.Output>,
+    SerializableType<T, "qs", qs.Input, qs.Output> {
   static fromJSON(options: json.Type): Ucs2StringType {
     const resolvedOptions: Options = {
       allowUnicodeRegExp: options.allowUnicodeRegExp,

--- a/src/test/helpers/test.ts
+++ b/src/test/helpers/test.ts
@@ -60,8 +60,8 @@ export function testValidValueSync(type: Type<any>, item: ValidTypedValue) {
   });
 }
 
-export function testBsonSerialization<T, Output, Input extends Output>(
-  type: SerializableType<T, "bson", Output, Input>,
+export function testBsonSerialization<T, Input, Output extends Input>(
+  type: SerializableType<T, "bson", Input, Output>,
   typedValue: ValidTypedValue
 ): void {
   let actualSerialized: Buffer;
@@ -90,14 +90,14 @@ export function testBsonSerialization<T, Output, Input extends Output>(
 
   it(`\`t.read("bson", t.write("bson", val))\` should be valid and equal to \`val\``, function () {
     const deserialized: Output = new BSON().deserialize(actualSerialized).wrapper;
-    const imported: T = type.read("bson", <Input> deserialized);
+    const imported: T = type.read("bson", deserialized);
     assert.isTrue(type.test(imported));
     assert.isTrue(type.equals(imported, typedValue.value));
   });
 }
 
-export function testJsonSerialization<T, Output, Input extends Output>(
-  type: SerializableType<T, "json", Output, Input>,
+export function testJsonSerialization<T, Input, Output extends Input>(
+  type: SerializableType<T, "json", Input, Output>,
   typedValue: ValidTypedValue
 ): void {
   let actualSerialized: string;
@@ -126,14 +126,14 @@ export function testJsonSerialization<T, Output, Input extends Output>(
 
   it(`\`t.read("json", t.write("json", val))\` should be valid and equal to \`val\``, function () {
     const deserialized: Output = JSON.parse(actualSerialized);
-    const imported: T = type.read("json", <Input> deserialized);
+    const imported: T = type.read("json", deserialized);
     assert.isTrue(type.test(imported));
     assert.isTrue(type.equals(imported, typedValue.value));
   });
 }
 
-export function testQsSerialization<T, Output, Input extends Output>(
-  type: SerializableType<T, "qs", Output, Input>,
+export function testQsSerialization<T, Input, Output extends Input>(
+  type: SerializableType<T, "qs", Input, Output>,
   typedValue: ValidTypedValue
 ): void {
   let actualSerialized: string;
@@ -162,7 +162,7 @@ export function testQsSerialization<T, Output, Input extends Output>(
 
   it(`\`t.read("qs", t.write("qs", val))\` should be valid and equal to \`val\``, function () {
     const deserialized: Output = qs.parse(actualSerialized).wrapper;
-    const imported: T = type.read("qs", <Input> deserialized);
+    const imported: T = type.read("qs", deserialized);
     assert.isTrue(type.test(imported));
     assert.isTrue(type.equals(imported, typedValue.value));
   });


### PR DESCRIPTION
`Output` now extends `Input`. This restores the order `T`, `Format`,`Input`, `Output`.

Closes #13