### PR TITLE
Implement `TaggedUnionType`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 - **[Feature]** Implement `LiteralType`
 - **[Feature]** Implement `UnionType`
+- **[Feature]** Implement `TaggedUnionType`. This is a subclass of UnionType to simplify
+  the definition of unions of documents with a "tag property". The tag property acts as
+  a discriminant and allows to retrieve the type of the whole document.
 - **[Feature]** Add the `rename` option to `DocumentType`. This allows to rename
   the keys of the document similarly to the values of `SimpleEnumType`.
 - **[Patch]** Fix the constraints for `SerializableType` generics.

--- a/src/lib/types/tagged-union.ts
+++ b/src/lib/types/tagged-union.ts
@@ -1,0 +1,146 @@
+import {Incident} from "incident";
+import {NotImplementedError} from "../errors/not-implemented";
+import {SerializableType} from "../interfaces";
+import {DocumentType} from "./document";
+import {LiteralType} from "./literal";
+import {SimpleEnumType} from "./simple-enum";
+import * as union from "./union";
+
+export type Name = "tagged-union";
+export const name: Name = "tagged-union";
+export namespace bson {
+  export interface Input {
+    [key: string]: any;
+  }
+  export interface Output {
+    [key: string]: any;
+  }
+}
+export namespace json {
+  export interface Input {
+    [key: string]: any;
+  }
+  export interface Output {
+    [key: string]: any;
+  }
+  export type Type = undefined;
+}
+export namespace qs {
+  export interface Input {
+    [key: string]: any;
+  }
+  export interface Output {
+    [key: string]: any;
+  }
+}
+export type Diff = any;
+
+export interface Options<T extends {}, Output, Input extends Output, Diff> {
+  variants: DocumentType<T>[];
+  tag: string;
+}
+
+function toUnionOptions<T extends {}>(options: Options<T, any, any, any>): union.Options<T, any, any, any> {
+  const tagName: string = options.tag;
+  let tagBaseType: SerializableType<any, any, any, any> | undefined = undefined;
+  const tagValuesMap: Map<number | string, DocumentType<T>> = new Map();
+  const outValuesMap: {
+    bson: Map<number | string, DocumentType<T>>,
+    json: Map<number | string, DocumentType<T>>,
+    qs: Map<number | string, DocumentType<T>>
+  } = {
+    bson: new Map(),
+    json: new Map(),
+    qs: new Map()
+  };
+
+  for (const variant of options.variants) {
+    if (!(tagName in variant.properties)) {
+      throw new Incident("TagNotFound", "Tag not found in variant of tagged union");
+    }
+    if (!(variant.properties[tagName].type instanceof LiteralType)) {
+      throw new Incident("NonLiteralTag", "Tag property must be a literal type");
+    }
+    const tagType: LiteralType<any> = variant.properties[tagName].type as LiteralType<any>;
+    if (tagBaseType === undefined) {
+      if (tagType.type instanceof SimpleEnumType) {
+        tagBaseType = tagType.type;
+      } else {
+        throw new Incident("InvalidTagBaseType", "The base type of a tag property must be a simple enum");
+      }
+    } else if (tagType.type !== tagBaseType) {
+      throw new Incident("MixedTagBaseType", "All the variants of a tag property must have the same base type");
+    }
+    if (!(typeof tagType.value === "number" || typeof tagType.value === "string")) {
+      throw new Incident("InvalidTagValue", "The value of a tag property must be a number or string");
+    }
+    const value: number | string = tagType.value;
+    if (tagValuesMap.has(value)) {
+      throw new Incident("DuplicateTagValue", "The tag values must be unique");
+    }
+    tagValuesMap.set(value, variant);
+    for (const format in outValuesMap) {
+      const value: string = tagBaseType.write(format, tagType.value);
+      if ((<any> outValuesMap)[format].has(value)) {
+        throw new Incident("DuplicateOutTagValue", `The tag values for ${format} must be unique`);
+      }
+      (<any> outValuesMap)[format].set(value, variant);
+    }
+  }
+  const matcher: union.Matcher<T, any, any, any> = (value: any) => {
+    if (typeof value !== "object" || value === null) {
+      return undefined;
+    }
+    return tagValuesMap.get(value[tagName]);
+  };
+  const trustedMatcher: union.TrustedMatcher<T, any, any, any> = (value: T) => {
+    return tagValuesMap.get((<any> value)[tagName])!;
+  };
+  const readMatcher: union.ReadMatcher<T, any, any, any> = (format: "bson" | "json" | "qs", value: any) => {
+    if (typeof value !== "object" || value === null) {
+      return undefined;
+    }
+    if (!(format in outValuesMap)) {
+      return undefined;
+    }
+    return (<any> outValuesMap)[format].get(value[tagName]);
+  };
+  const readTrustedMatcher: union.ReadTrustedMatcher<T, any, any, any> = (
+    format: "bson" | "json" | "qs",
+    value: T
+  ) => {
+    return (<any> outValuesMap)[format].get((<any> value)[tagName])!;
+  };
+  return {variants: options.variants, matcher, trustedMatcher, readMatcher, readTrustedMatcher};
+}
+
+export class TaggedUnionType<T extends {}> extends union.UnionType<T> {
+  readonly names: string[] = [this.name, name];
+  readonly variants: DocumentType<T>[];
+
+  constructor(options: Options<T, any, any, any>) {
+    super(toUnionOptions(options));
+  }
+
+  toJSON(): json.Type {
+    throw NotImplementedError.create("TaggedUnionType#toJSON");
+  }
+
+  diff(oldVal: T, newVal: T): Diff | undefined {
+    throw NotImplementedError.create("TaggedUnionType#diff");
+  }
+
+  patch(oldVal: T, diff: Diff | undefined): T {
+    throw NotImplementedError.create("TaggedUnionType#patch");
+  }
+
+  reverseDiff(diff: Diff | undefined): Diff | undefined {
+    throw NotImplementedError.create("TaggedUnionType#reverseDiff");
+  }
+
+  squash(diff1: Diff | undefined, diff2: Diff | undefined): Diff | undefined {
+    throw NotImplementedError.create("TaggedUnionType#squash");
+  }
+}
+
+export {TaggedUnionType as Type};

--- a/src/lib/types/union.ts
+++ b/src/lib/types/union.ts
@@ -36,12 +36,18 @@ export type ReadMatcher<T, Output, Input extends Output, Diff> = (
   variants: VersionedType<T, Output, Input, Diff>[]
 ) => VersionedType<T, Output, Input, Diff> | undefined;
 
+export type ReadTrustedMatcher<T, Output, Input extends Output, Diff> = (
+  format: "bson" | "json" | "qs",
+  value: T,
+  variants: VersionedType<T, Output, Input, Diff>[]
+) => VersionedType<T, Output, Input, Diff>;
+
 export interface Options<T, Output, Input extends Output, Diff> {
   variants: VersionedType<T, Output, Input, Diff>[];
   matcher: Matcher<T, Output, Input, Diff>;
   trustedMatcher?: TrustedMatcher<T, Output, Input, Diff>;
   readMatcher: ReadMatcher<T, Output, Input, Diff>;
-  readTrustedMatcher?: ReadMatcher<T, Output, Input, Diff>;
+  readTrustedMatcher?: ReadTrustedMatcher<T, Output, Input, Diff>;
 }
 
 export class UnionType<T>
@@ -52,15 +58,15 @@ export class UnionType<T>
   readonly variants: VersionedType<T, any, any, Diff>[];
   readonly matcher: Matcher<T, any, any, Diff>;
   readonly trustedMatcher: TrustedMatcher<T, any, any, Diff>;
-  readonly readTrustedMatcher: ReadMatcher<T, any, any, Diff>;
   readonly readMatcher: ReadMatcher<T, any, any, Diff>;
+  readonly readTrustedMatcher: ReadTrustedMatcher<T, any, any, Diff>;
 
   constructor(options: Options<T, any, any, any>) {
     this.variants = options.variants;
     this.matcher = options.matcher;
     this.trustedMatcher = options.trustedMatcher || this.matcher as TrustedMatcher<T, any, any, Diff>;
     this.readMatcher = options.readMatcher;
-    this.readTrustedMatcher = options.readTrustedMatcher || this.readMatcher;
+    this.readTrustedMatcher = options.readTrustedMatcher || this.readMatcher as ReadTrustedMatcher<T, any, any, Diff>;
   }
 
   toJSON(): json.Type {
@@ -72,7 +78,7 @@ export class UnionType<T>
   readTrusted(format: "qs", val: qs.Output): T;
   readTrusted(format: "bson" | "json" | "qs", input: any): T {
     // TODO(demurgos): Check if the format is supported instead of casting to `any`
-    return this.readTrustedMatcher(format, input, this.variants)!.readTrusted(<any> format, input);
+    return this.readTrustedMatcher(format, input, this.variants).readTrusted(<any> format, input);
   }
 
   read(format: "bson" | "json" | "qs", input: any): T {

--- a/src/test/types/tagged-union.spec.ts
+++ b/src/test/types/tagged-union.spec.ts
@@ -3,11 +3,11 @@ import {DocumentType} from "../../lib/types/document";
 import {Int32Type} from "../../lib/types/int32";
 import {LiteralType} from "../../lib/types/literal";
 import {SimpleEnumType} from "../../lib/types/simple-enum";
-import {UnionType} from "../../lib/types/union";
+import {TaggedUnionType} from "../../lib/types/tagged-union";
 import {runTests, TypedValue} from "../helpers/test";
 
-describe("Union", function () {
-  describe("Union<Shape>", function () {
+describe("TaggedUnion", function () {
+  describe("TaggedUnion<Shape>", function () {
     enum ShapeType {
       Rectangle,
       Circle
@@ -54,44 +54,9 @@ describe("Union", function () {
     });
 
     type Shape = Rectangle | Circle;
-    const shapeType: UnionType<Shape> = new UnionType<Shape>({
+    const shapeType: TaggedUnionType<Shape> = new TaggedUnionType<Shape>({
       variants: [rectangleType, circleType],
-      readMatcher: (format: string, val: any) => {
-        if (typeof val !== "object" || val === null) {
-          return undefined;
-        }
-        switch (val.type) {
-          case "circle":
-            return circleType;
-          case "rectangle":
-            return rectangleType;
-          default:
-            return undefined;
-        }
-      },
-      matcher: (val: Shape) => {
-        if (typeof val !== "object" || val === null) {
-          return undefined;
-        }
-        switch (val.type) {
-          case ShapeType.Circle:
-            return circleType;
-          case ShapeType.Rectangle:
-            return rectangleType;
-          default:
-            return undefined;
-        }
-      },
-      trustedMatcher: (val: Shape) => {
-        switch (val.type) {
-          case ShapeType.Circle:
-            return circleType;
-          case ShapeType.Rectangle:
-            return rectangleType;
-          default:
-            return undefined as never;
-        }
-      }
+      tag: "type"
     });
 
     const items: TypedValue[] = [


### PR DESCRIPTION
This is a subclass of UnionType to simplify the definition of unions of documents with a "tag property". The tag property acts as a discriminant and allows to retrieve the type of the whole document.

Closes #5