### PR TITLE
Use `itemType.read` in `ArrayType#read`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Next
+
+- **[Patch]** `ArrayType#read` now uses `itemType.read` (instead of `.readTrusted`).
+
 # 0.5.0-alpha.6
 
 - **[Feature]** Implement `MapType`

--- a/src/lib/types/array.ts
+++ b/src/lib/types/array.ts
@@ -75,12 +75,12 @@ export class ArrayType<T>
           throw WrongTypeError.create("array", input);
         }
         // TODO(demurgos): Check if the format is supported instead of casting to `any`
-        result = input.map((item: any): T => this.itemType.readTrusted(<any> format, item));
+        result = input.map((item: any): T => this.itemType.read(<any> format, item));
         break;
       case "qs":
         if (Array.isArray(input)) {
           // TODO(demurgos): Check if the format is supported instead of casting to `any`
-          result = input.map((item: any): T => this.itemType.readTrusted(<any> format, item));
+          result = input.map((item: any): T => this.itemType.read(<any> format, item));
         } else if (input === undefined) {
           result = [];
         } else {


### PR DESCRIPTION
`ArrayType#read` was previously using `readTrusted` instead of checking its items.