### PR TITLE
Release v0.5.0-alpha.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Next
+# 0.5.0-alpha.7 (2017-07-10)
 
 - **[Feature]** Implement `BufferType`
 - **[Fix]** `ArrayType#read` now uses `itemType.read` (instead of `.readTrusted`).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kryo",
-  "version": "0.5.0-alpha.6",
+  "version": "0.5.0-alpha.7",
   "description": "Serialization for documents.",
   "main": "dist/lib-es2015/lib/index.es2015.js",
   "types": "dist/lib-es2015/lib/index.es2015.d.ts",


### PR DESCRIPTION
- **[Feature]** Implement `BufferType`
- **[Fix]** `ArrayType#read` now uses `itemType.read` (instead of `.readTrusted`).
- **[Fix]** Do not type value for `readMatcher` and `readMatcher`, used by the general `UnionType`.