### PR TITLE
Release v0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Next
+# 0.6.1 (2018-01-30)
 
 - **[Fix]** Use `{}` instead of `Object.create(null)` when creating new objects in `DocumentType`.
   Quickfix for [chaijs/deep-eql#51](https://github.com/chaijs/deep-eql/issues/51).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "kryo",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kryo",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Serialization for documents.",
   "main": "dist/lib/index",
   "types": "dist/lib/index.d.ts",


### PR DESCRIPTION
- **[Fix]** Use `{}` instead of `Object.create(null)` when creating new objects in `DocumentType`.