### PR TITLE
Release v0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Next
 
+- **[Breaking change]** Rename `buffer` to `bytes` (`BufferType` to `BytesType`,
+  `fromBuffer` to `fromBytes`, etc.) 
 - **[Internal]** Remove unused `json` namespaces.
 
 # 0.7.0-beta.2 (2018-02-07)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 - **[Breaking change]** Rename `buffer` to `bytes` (`BufferType` to `BytesType`,
   `fromBuffer` to `fromBytes`, etc.) 
+- **[Breaking change]** Rename `kryo/types` to `kryo/core` to avoid confusion with the `types`
+  directory.
 - **[Internal]** Remove unused `json` namespaces.
 
 # 0.7.0-beta.2 (2018-02-07)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - **[Breaking change]** Make `.testError` optional.
 - **[Feature]** Add `Ord` interface for types supporting comparison. Implement it to provide total
   order for float64, integer, date, bytes and boolean.
+- **[Feature]** Add `$Bytes` and `$Ucs2String` builtins.
 - **[Internal]** Remove unused `json` namespaces.
 
 # 0.7.0-beta.2 (2018-02-07)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Next
+# 0.7.0 (2018-02-26)
 
 - **[Breaking change]** Rename `buffer` to `bytes` (`BufferType` to `BytesType`,
   `fromBuffer` to `fromBytes`, etc.) 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
   order for float64, integer, date, bytes and boolean.
 - **[Feature]** Add `$Bytes` and `$Ucs2String` builtins.
 - **[Internal]** Remove unused `json` namespaces.
+- **[Internal]** Update dependencies
 
 # 0.7.0-beta.2 (2018-02-07)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
   `fromBuffer` to `fromBytes`, etc.) 
 - **[Breaking change]** Rename `kryo/types` to `kryo/core` to avoid confusion with the `types`
   directory.
+- **[Breaking change]** Make `.testError` optional.
+- **[Feature]** Add `Ord` interface for types supporting comparison. Implement it to provide total
+  order for float64, integer, date, bytes and boolean.
 - **[Internal]** Remove unused `json` namespaces.
 
 # 0.7.0-beta.2 (2018-02-07)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Next
+
+- **[Internal]** Remove unused `json` namespaces.
+
 # 0.7.0-beta.2 (2018-02-07)
 
 - **[Fix]** Publish source `.ts` files in a different directory than the corresponding `.js` and `.d.ts`.

--- a/README.md
+++ b/README.md
@@ -57,8 +57,8 @@ outdated.**
 A Kryo **Type** represents a set of valid values. Kryo provides you multiple builtin types and
 utilities to easily create your own types.
 
-It is simply an object with methods to:
-- test if a value is valid (`.test` and `.testError`)
+It is simply an object with 3 methods to:
+- test if a value is valid (`.test`)
 - check if two valid values are equivalent (`.equals`)
 - create a deep copy of a valid value (`.clone`)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "kryo",
-  "version": "0.7.0-beta.2",
+  "version": "0.7.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,7 @@
       "resolved": "https://registry.npmjs.org/@types/bson/-/bson-1.0.6.tgz",
       "integrity": "sha512-v7N8qcTGiYhLRyi+Y69R3tPC4GLqByCg3NC2EO6PciC166O9dNhjFPoXeMePtZ+0f+/O2xLDWXs5BLnRfcBaBA==",
       "requires": {
-        "@types/node": "9.4.1"
+        "@types/node": "9.4.6"
       }
     },
     "@types/chai": {
@@ -62,7 +62,7 @@
       "dev": true,
       "requires": {
         "@types/events": "1.1.0",
-        "@types/node": "9.4.1"
+        "@types/node": "9.4.6"
       }
     },
     "@types/del": {
@@ -92,7 +92,7 @@
       "integrity": "sha512-qtxDULQKUenuaDLW003CgC+0T0eiAfH3BrH+vSt87GLzbz5EZ6Ox6mv9rMttvhDOatbb9nYh0E1m7ydoYwUrAg==",
       "dev": true,
       "requires": {
-        "@types/node": "9.4.1"
+        "@types/node": "9.4.6"
       }
     },
     "@types/glob": {
@@ -103,7 +103,7 @@
       "requires": {
         "@types/events": "1.1.0",
         "@types/minimatch": "3.0.3",
-        "@types/node": "9.4.1"
+        "@types/node": "9.4.6"
       }
     },
     "@types/glob-stream": {
@@ -113,7 +113,7 @@
       "dev": true,
       "requires": {
         "@types/glob": "5.0.35",
-        "@types/node": "9.4.1"
+        "@types/node": "9.4.6"
       }
     },
     "@types/gulp": {
@@ -133,7 +133,7 @@
       "integrity": "sha512-v0KhxGFtk/p4tZ6N20LoE7CgH4KSvu5PrUqx0dS9001DCsU/tsnNLYG7H3b8eZ4lovRgsJYY0m1w1VJ3cxBPag==",
       "dev": true,
       "requires": {
-        "@types/node": "9.4.1",
+        "@types/node": "9.4.6",
         "@types/pug": "2.0.4"
       }
     },
@@ -143,7 +143,7 @@
       "integrity": "sha512-FIZQvbZJj6V1gHPTzO+g/BCWpDur7fJrroae4gwV3LaoHBQ+MrR9sB+2HssK8fHv4WdY6hVNxkcft9bYatuPIA==",
       "dev": true,
       "requires": {
-        "@types/node": "9.4.1"
+        "@types/node": "9.4.6"
       }
     },
     "@types/gulp-sourcemaps": {
@@ -152,7 +152,7 @@
       "integrity": "sha512-+7BAmptW2bxyJnJcCEuie7vLoop3FwWgCdBMzyv7MYXED/HeNMeQuX7uPCkp4vfU1TTu4CYFH0IckNPvo0VePA==",
       "dev": true,
       "requires": {
-        "@types/node": "9.4.1"
+        "@types/node": "9.4.6"
       }
     },
     "@types/handlebars": {
@@ -185,7 +185,7 @@
       "integrity": "sha512-GjaXY4OultxbaOOk7lCLO7xvEcFpdjExC605YmfI6X29vhHKpJfMWKCDZd3x+BITrZaXKg97DgV/SdGVSwdzxA==",
       "dev": true,
       "requires": {
-        "@types/node": "9.4.1"
+        "@types/node": "9.4.6"
       }
     },
     "@types/minimatch": {
@@ -207,9 +207,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "9.4.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-9.4.1.tgz",
-      "integrity": "sha512-9ESUxmXt1Isc1xKfDBZ7tpULyTPY5ZCywcfvQTXoLUqP+n4D+MBH+0n75hdzrcmfCc3eWByOi27+GLmMuAvcUA=="
+      "version": "9.4.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-9.4.6.tgz",
+      "integrity": "sha512-CTUtLb6WqCCgp6P59QintjHWqzf4VL1uPA27bipLAPxFqrtK1gEYllePzTICGqQ8rYsCbpnsNypXjjDzGAAjEQ=="
     },
     "@types/object-inspect": {
       "version": "1.4.0",
@@ -222,7 +222,7 @@
       "integrity": "sha512-cKB4yTX0wGaRCSkdHDX2fkGQbMAA8UOshC2U7DQky1CE5o+5q2iQQ8VkbPbE/88uaTtsusvBPMcCX7dgmjxBhQ==",
       "dev": true,
       "requires": {
-        "@types/node": "9.4.1",
+        "@types/node": "9.4.6",
         "@types/q": "1.0.7"
       }
     },
@@ -257,20 +257,8 @@
       "dev": true,
       "requires": {
         "@types/glob": "5.0.35",
-        "@types/node": "9.4.1"
+        "@types/node": "9.4.6"
       }
-    },
-    "@types/strip-bom": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@types/strip-bom/-/strip-bom-3.0.0.tgz",
-      "integrity": "sha1-FKjsOVbC6B7bdSB5CuzyHCkK69I=",
-      "dev": true
-    },
-    "@types/strip-json-comments": {
-      "version": "0.0.30",
-      "resolved": "https://registry.npmjs.org/@types/strip-json-comments/-/strip-json-comments-0.0.30.tgz",
-      "integrity": "sha512-7NQmHra/JILCd1QqpSzl8+mJRc8ZHz3uDm8YV1Ks9IhK0epEiTw8aIErbvH9PI+6XbqhyIQy3462nEsn7UVzjQ==",
-      "dev": true
     },
     "@types/tmp": {
       "version": "0.0.33",
@@ -305,7 +293,7 @@
       "integrity": "sha512-2iYpNuOl98SrLPBZfEN9Mh2JCJ2EI9HU35SfgBEb51DcmaHkhp8cKMblYeBqMQiwXMgAD3W60DbQ4i/UdLiXhw==",
       "dev": true,
       "requires": {
-        "@types/node": "9.4.1"
+        "@types/node": "9.4.6"
       }
     },
     "@types/vinyl-fs": {
@@ -315,7 +303,7 @@
       "dev": true,
       "requires": {
         "@types/glob-stream": "6.1.0",
-        "@types/node": "9.4.1",
+        "@types/node": "9.4.6",
         "@types/vinyl": "2.0.2"
       }
     },
@@ -4515,9 +4503,9 @@
       }
     },
     "make-error": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.3.tgz",
-      "integrity": "sha512-j3dZCri3cCd23wgPqK/0/KvTN8R+W6fXDqQe8BNLbTpONjbA8SPaRr+q0BQq9bx3Q/+g68/gDIh9FW3by702Tg==",
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.4.tgz",
+      "integrity": "sha512-0Dab5btKVPhibSalc9QGXb559ED7G7iLjFXBaj9Wq8O3vorueR5K5jaE3hkG6ZQINyhA/JgG6Qk4qdFQjsYV6g==",
       "dev": true
     },
     "make-iterator": {
@@ -8523,12 +8511,6 @@
         "get-stdin": "4.0.1"
       }
     },
-    "strip-json-comments": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
-      "dev": true
-    },
     "supports-color": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
@@ -8805,41 +8787,19 @@
       }
     },
     "ts-node": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-4.1.0.tgz",
-      "integrity": "sha512-xcZH12oVg9PShKhy3UHyDmuDLV3y7iKwX25aMVPt1SIXSuAfWkFiGPEkg+th8R4YKW/QCxDoW7lJdb15lx6QWg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-5.0.0.tgz",
+      "integrity": "sha512-mlSim/sQS1s5iT3KZEKXRaqsGC7xM2QoxkrhfznZJyou18dl47PTnY7/KMmbGqiVoQrO9Hk53CYpcychF5TNrQ==",
       "dev": true,
       "requires": {
         "arrify": "1.0.1",
         "chalk": "2.3.0",
         "diff": "3.4.0",
-        "make-error": "1.3.3",
+        "make-error": "1.3.4",
         "minimist": "1.2.0",
         "mkdirp": "0.5.1",
         "source-map-support": "0.5.3",
-        "tsconfig": "7.0.0",
-        "v8flags": "3.0.1",
         "yn": "2.0.0"
-      }
-    },
-    "tsconfig": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/tsconfig/-/tsconfig-7.0.0.tgz",
-      "integrity": "sha512-vZXmzPrL+EmC4T/4rVlT2jNVMWCi/O4DIiSj3UHg1OE5kCKbk4mfrXc6dZksLgRM/TZlKnousKH9bbTazUWRRw==",
-      "dev": true,
-      "requires": {
-        "@types/strip-bom": "3.0.0",
-        "@types/strip-json-comments": "0.0.30",
-        "strip-bom": "3.0.0",
-        "strip-json-comments": "2.0.1"
-      },
-      "dependencies": {
-        "strip-bom": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
-          "dev": true
-        }
       }
     },
     "tslib": {
@@ -8946,7 +8906,7 @@
         "tslint": "5.9.1",
         "typedoc": "0.10.0",
         "typedoc-plugin-external-module-name": "1.1.1",
-        "typescript": "2.7.1",
+        "typescript": "2.7.2",
         "vinyl": "2.1.0",
         "vinyl-buffer": "1.0.1",
         "vinyl-source-stream": "2.0.0",
@@ -8997,6 +8957,14 @@
         "shelljs": "0.8.1",
         "typedoc-default-themes": "0.5.0",
         "typescript": "2.7.1"
+      },
+      "dependencies": {
+        "typescript": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.7.1.tgz",
+          "integrity": "sha512-bqB1yS6o9TNA9ZC/MJxM0FZzPnZdtHj0xWK/IZ5khzVqdpGul/R/EIiHRgFXlwTD7PSIaYVnGKq1QgMCu2mnqw==",
+          "dev": true
+        }
       }
     },
     "typedoc-default-themes": {
@@ -9012,9 +8980,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.7.1.tgz",
-      "integrity": "sha512-bqB1yS6o9TNA9ZC/MJxM0FZzPnZdtHj0xWK/IZ5khzVqdpGul/R/EIiHRgFXlwTD7PSIaYVnGKq1QgMCu2mnqw==",
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.7.2.tgz",
+      "integrity": "sha512-p5TCYZDAO0m4G344hD+wx/LATebLWZNkkh2asWUFqSsD2OrDNhbAHuSjobrmsUmdzjJjEeZVU9g1h3O6vpstnw==",
       "dev": true
     },
     "uglify-js": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kryo",
-  "version": "0.7.0-beta.2",
+  "version": "0.7.0",
   "description": "Runtime types",
   "main": "dist/lib/index",
   "types": "dist/lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kryo",
   "version": "0.7.0-beta.2",
-  "description": "Serialization for documents.",
+  "description": "Runtime types",
   "main": "dist/lib/index",
   "types": "dist/lib/index.d.ts",
   "private": true,

--- a/package.json
+++ b/package.json
@@ -40,8 +40,8 @@
   "devDependencies": {
     "@types/chai": "^4.1.2",
     "@types/minimist": "^1.2.0",
-    "@types/mocha": "^2.2.47",
-    "@types/node": "^9.4.0",
+    "@types/mocha": "^2.2.48",
+    "@types/node": "^9.4.6",
     "@types/qs": "^6.5.1",
     "chai": "^4.1.2",
     "codecov": "^3.0.0",
@@ -50,9 +50,9 @@
     "minimist": "^1.2.0",
     "pre-commit": "^1.2.2",
     "qs": "^6.5.1",
-    "ts-node": "^4.1.0",
+    "ts-node": "^5.0.0",
     "turbo-gulp": "^0.16.2",
-    "typescript": "^2.7.1"
+    "typescript": "^2.7.2"
   },
   "nyc": {
     "include": [

--- a/src/lib/builtins/any.ts
+++ b/src/lib/builtins/any.ts
@@ -1,3 +1,7 @@
+/**
+ * @module kryo/builtins/any
+ */
+
 import { AnyType } from "../types/any";
 
 export const $Any: AnyType = new AnyType();

--- a/src/lib/builtins/boolean.ts
+++ b/src/lib/builtins/boolean.ts
@@ -1,3 +1,7 @@
+/**
+ * @module kryo/builtins/boolean
+ */
+
 import { BooleanType } from "../types/boolean";
 
 export const $Boolean: BooleanType = new BooleanType();

--- a/src/lib/builtins/bytes.ts
+++ b/src/lib/builtins/bytes.ts
@@ -1,0 +1,7 @@
+/**
+ * @module kryo/builtins/bytes
+ */
+
+import { BytesType } from "../types/bytes";
+
+export const $Bytes: BytesType = new BytesType({maxLength: Infinity});

--- a/src/lib/builtins/date.ts
+++ b/src/lib/builtins/date.ts
@@ -1,3 +1,7 @@
+/**
+ * @module kryo/builtins/date
+ */
+
 import { DateType } from "../types/date";
 
 export const $Date: DateType = new DateType();

--- a/src/lib/builtins/sint16.ts
+++ b/src/lib/builtins/sint16.ts
@@ -1,3 +1,7 @@
+/**
+ * @module kryo/builtins/sint16
+ */
+
 import { IntegerType } from "../types/integer";
 
 export const $Sint16: IntegerType = new IntegerType({min: -32768, max: 32767});

--- a/src/lib/builtins/sint32.ts
+++ b/src/lib/builtins/sint32.ts
@@ -1,3 +1,7 @@
+/**
+ * @module kryo/builtins/sint32
+ */
+
 import { IntegerType } from "../types/integer";
 
 export const $Sint32: IntegerType = new IntegerType({min: -2147483648, max: 2147483647});

--- a/src/lib/builtins/sint54.ts
+++ b/src/lib/builtins/sint54.ts
@@ -1,3 +1,7 @@
+/**
+ * @module kryo/builtins/sint54
+ */
+
 import { IntegerType } from "../types/integer";
 
 export const $Sint54: IntegerType = new IntegerType({min: -9007199254740992, max: 9007199254740991});

--- a/src/lib/builtins/sint8.ts
+++ b/src/lib/builtins/sint8.ts
@@ -1,3 +1,7 @@
+/**
+ * @module kryo/builtins/sint8
+ */
+
 import { IntegerType } from "../types/integer";
 
 export const $Sint8: IntegerType = new IntegerType({min: -128, max: 127});

--- a/src/lib/builtins/ucs2-string.ts
+++ b/src/lib/builtins/ucs2-string.ts
@@ -1,0 +1,7 @@
+/**
+ * @module kryo/builtins/ucs2-string
+ */
+
+import { Ucs2StringType } from "../types/ucs2-string";
+
+export const $Ucs2String: Ucs2StringType = new Ucs2StringType({maxLength: Infinity});

--- a/src/lib/builtins/uint16.ts
+++ b/src/lib/builtins/uint16.ts
@@ -1,3 +1,7 @@
+/**
+ * @module kryo/builtins/uint16
+ */
+
 import { IntegerType } from "../types/integer";
 
 export const $Uint16: IntegerType = new IntegerType({min: 0, max: 65535});

--- a/src/lib/builtins/uint32.ts
+++ b/src/lib/builtins/uint32.ts
@@ -1,3 +1,7 @@
+/**
+ * @module kryo/builtins/uint32
+ */
+
 import { IntegerType } from "../types/integer";
 
 export const $Uint32: IntegerType = new IntegerType({min: 0, max: 4294967295});

--- a/src/lib/builtins/uint53.ts
+++ b/src/lib/builtins/uint53.ts
@@ -1,3 +1,7 @@
+/**
+ * @module kryo/builtins/uint53
+ */
+
 import { IntegerType } from "../types/integer";
 
 export const $Uint53: IntegerType = new IntegerType({min: 0, max: 9007199254740991});

--- a/src/lib/builtins/uint8.ts
+++ b/src/lib/builtins/uint8.ts
@@ -1,3 +1,7 @@
+/**
+ * @module kryo/builtins/uint8
+ */
+
 import { IntegerType } from "../types/integer";
 
 export const $Uint8: IntegerType = new IntegerType({min: 0, max: 255});

--- a/src/lib/builtins/uuid-hex.ts
+++ b/src/lib/builtins/uuid-hex.ts
@@ -1,3 +1,7 @@
+/**
+ * @module kryo/builtins/uuid-hex
+ */
+
 import { Ucs2StringType } from "../types/ucs2-string";
 
 /**

--- a/src/lib/case-style.ts
+++ b/src/lib/case-style.ts
@@ -1,3 +1,9 @@
+/**
+ * This module defines utility functions to detect and change case styles.
+ *
+ * @module kryo/case-style
+ */
+
 import { Incident } from "incident";
 
 export enum CaseStyle {

--- a/src/lib/core.ts
+++ b/src/lib/core.ts
@@ -24,15 +24,6 @@ export interface Type<T> {
   name?: string;
 
   /**
-   * Tests if this type matches `value`, describes the error if not.
-   *
-   * @param value The value to test against this type.
-   * @return If this type matches `value` then `undefined`; otherwise an error describing why this
-   *         type does not match `value`.
-   */
-  testError(value: T): Error | undefined;
-
-  /**
    * Tests if this type matches `value`.
    *
    * @param value The value to test against this type.
@@ -68,9 +59,45 @@ export interface Type<T> {
    */
   clone(value: T): T;
 
+  /**
+   * Tests if this type matches `value`, describes the error if not.
+   *
+   * @param value The value to test against this type.
+   * @return If this type matches `value` then `undefined`; otherwise an error describing why this
+   *         type does not match `value`.
+   */
+  testError?(value: T): Error | undefined;
+
+  /**
+   * Compares two valid values.
+   *
+   * @param left Left operand, a valid value.
+   * @param right Right operand, a valid value.
+   * @return Boolean indicating if `left <= right` is true.
+   */
+  lte?(left: T, right: T): boolean;
+
+  /**
+   * Serializes the valid value `value`.
+   *
+   * @param writer Writer used to emit the data.
+   * @param value Value to serialize.
+   * @return Writer result.
+   */
   write?<W>(writer: Writer<W>, value: T): W;
 
-  read?<R>(reader: Reader<R>, raw: R): T;
+  /**
+   * Deserializes a value of this type.
+   *
+   * @param reader Reader to drive during the deserialization.
+   * @param input Reader input.
+   * @return Valid value.
+   */
+  read?<R>(reader: Reader<R>, input: R): T;
+}
+
+export interface Ord<T> {
+  lte(left: T, right: T): boolean;
 }
 
 export interface Writable<T> {
@@ -82,7 +109,8 @@ export interface Readable<T> {
 }
 
 /**
- * Represents a type suitable for IO operations: this type supports serialization and deserialization.
+ * Represents a type suitable for IO operations: this type supports both serialization and
+ * deserialization.
  */
 export interface IoType<T> extends Type<T>, Readable<T>, Writable<T> {
   write<W>(writer: Writer<W>, value: T): W;

--- a/src/lib/core.ts
+++ b/src/lib/core.ts
@@ -1,7 +1,7 @@
 /**
  * This module defines most of the Typescript interfaces and type aliases used by Kryo.
  *
- * @module kryo/types
+ * @module kryo/core
  */
 
 /**

--- a/src/lib/errors/invalid-value.ts
+++ b/src/lib/errors/invalid-value.ts
@@ -1,0 +1,17 @@
+import { Incident } from "incident";
+import { Type } from "../core";
+
+export type Name = "InvalidValue";
+export const name: Name = "InvalidValue";
+
+export interface Data {
+  type: Type<any>;
+  value: any;
+}
+
+export type Cause = undefined;
+export type InvalidValueError = Incident<Data, Name, Cause>;
+
+export function createInvalidValueError(type: Type<any>, value: any): InvalidValueError {
+  return new Incident(name, {type, value});
+}

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,3 +1,17 @@
+/**
+ * This is a placeholder module: you should never import it. Trying to import it will result in a
+ * runtime error.
+ *
+ * Use deep module imports to directly import components you need.
+ *
+ * For example, to import the `DocumentType` type constructor, use:
+ * ```typescript
+ * import { DocumentType } from "kryo/types/document";
+ * ```
+ *
+ * @module kryo
+ */
+
 import { Incident } from "incident";
 
 throw new Incident(

--- a/src/lib/json-value.ts
+++ b/src/lib/json-value.ts
@@ -1,6 +1,22 @@
+/**
+ * This module defines the `JsonValue` type. This is a stronger alternative to `any` for the
+ * return type of `JSON.parse(str)`.
+ *
+ * @module kryo/json-value
+ */
+
+/**
+ * Represents an atomic JSON value or a JSON object.
+ */
 export type JsonBaseValue = boolean | string | null | number | {[P in keyof any]: JsonValue};
 
+/**
+ * Represents an array of JSON values.
+ */
 export interface JsonArrayValue extends Array<JsonValue> {
 }
 
+/**
+ * Represents a JSON value: a value returned by `JSON.parse(str)`.
+ */
 export type JsonValue = JsonArrayValue | JsonBaseValue;

--- a/src/lib/readers/bson-value.ts
+++ b/src/lib/readers/bson-value.ts
@@ -4,8 +4,8 @@
 
 import bson from "bson";
 import { Incident } from "incident";
+import { Reader, ReadVisitor } from "../core";
 import { createInvalidTypeError } from "../errors/invalid-type";
-import { Reader, ReadVisitor } from "../types";
 import { JsonReader } from "./json";
 
 function isBinary(val: any): val is bson.Binary {

--- a/src/lib/readers/bson-value.ts
+++ b/src/lib/readers/bson-value.ts
@@ -37,7 +37,7 @@ export class BsonValueReader implements Reader<any> {
     return visitor.fromBoolean(input);
   }
 
-  readBuffer<R>(raw: any, visitor: ReadVisitor<R>): R {
+  readBytes<R>(raw: any, visitor: ReadVisitor<R>): R {
     let input: Uint8Array;
     if (isBinary(raw)) {
       // TODO: Fix BSON type definitions
@@ -46,7 +46,7 @@ export class BsonValueReader implements Reader<any> {
       // TODO: typecheck
       input = raw;
     }
-    return visitor.fromBuffer(input);
+    return visitor.fromBytes(input);
   }
 
   readDate<R>(raw: any, visitor: ReadVisitor<R>): R {

--- a/src/lib/readers/bson-value.ts
+++ b/src/lib/readers/bson-value.ts
@@ -1,3 +1,7 @@
+/**
+ * @module kryo/readers/bson-value
+ */
+
 import bson from "bson";
 import { Incident } from "incident";
 import { createInvalidTypeError } from "../errors/invalid-type";

--- a/src/lib/readers/bson.ts
+++ b/src/lib/readers/bson.ts
@@ -26,8 +26,8 @@ export class BsonReader implements Reader<Buffer> {
     return this.valueReader.readBoolean(this.bsonSerializer.deserialize(raw)[this.primitiveWrapper], visitor);
   }
 
-  readBuffer<R>(raw: Buffer, visitor: ReadVisitor<R>): R {
-    return this.valueReader.readBuffer(this.bsonSerializer.deserialize(raw)[this.primitiveWrapper], visitor);
+  readBytes<R>(raw: Buffer, visitor: ReadVisitor<R>): R {
+    return this.valueReader.readBytes(this.bsonSerializer.deserialize(raw)[this.primitiveWrapper], visitor);
   }
 
   readDate<R>(raw: Buffer, visitor: ReadVisitor<R>): R {

--- a/src/lib/readers/bson.ts
+++ b/src/lib/readers/bson.ts
@@ -1,3 +1,7 @@
+/**
+ * @module kryo/readers/bson
+ */
+
 import _bson from "bson";
 import { Reader, ReadVisitor } from "../types";
 import { BsonValueReader } from "./bson-value";

--- a/src/lib/readers/bson.ts
+++ b/src/lib/readers/bson.ts
@@ -3,7 +3,7 @@
  */
 
 import _bson from "bson";
-import { Reader, ReadVisitor } from "../types";
+import { Reader, ReadVisitor } from "../core";
 import { BsonValueReader } from "./bson-value";
 
 export class BsonReader implements Reader<Buffer> {

--- a/src/lib/readers/json-value.ts
+++ b/src/lib/readers/json-value.ts
@@ -32,7 +32,7 @@ export class JsonValueReader implements Reader<JsonValue> {
     return visitor.fromBoolean(raw);
   }
 
-  readBuffer<R>(raw: JsonValue, visitor: ReadVisitor<R>): R {
+  readBytes<R>(raw: JsonValue, visitor: ReadVisitor<R>): R {
     if (typeof raw !== "string") {
       throw createInvalidTypeError("string", raw);
     } else if (!/^(?:[0-9a-f]{2})*$/.test(raw)) {
@@ -44,7 +44,7 @@ export class JsonValueReader implements Reader<JsonValue> {
     for (let i: number = 0; i < len; i++) {
       result[i] = parseInt(raw.substr(2 * i, 2), 16);
     }
-    return visitor.fromBuffer(result);
+    return visitor.fromBytes(result);
   }
 
   readDate<R>(raw: JsonValue, visitor: ReadVisitor<R>): R {

--- a/src/lib/readers/json-value.ts
+++ b/src/lib/readers/json-value.ts
@@ -1,3 +1,7 @@
+/**
+ * @module kryo/readers/json-value
+ */
+
 import { Incident } from "incident";
 import { createInvalidTypeError } from "../errors/invalid-type";
 import { JsonValue } from "../json-value";

--- a/src/lib/readers/json-value.ts
+++ b/src/lib/readers/json-value.ts
@@ -3,9 +3,9 @@
  */
 
 import { Incident } from "incident";
+import { Reader, ReadVisitor } from "../core";
 import { createInvalidTypeError } from "../errors/invalid-type";
 import { JsonValue } from "../json-value";
-import { Reader, ReadVisitor } from "../types";
 
 export class JsonValueReader implements Reader<JsonValue> {
   trustInput?: boolean | undefined;

--- a/src/lib/readers/json.ts
+++ b/src/lib/readers/json.ts
@@ -2,7 +2,7 @@
  * @module kryo/readers/json
  */
 
-import { Reader, ReadVisitor } from "../types";
+import { Reader, ReadVisitor } from "../core";
 import { JsonValueReader } from "./json-value";
 
 export class JsonReader implements Reader<string> {

--- a/src/lib/readers/json.ts
+++ b/src/lib/readers/json.ts
@@ -19,8 +19,8 @@ export class JsonReader implements Reader<string> {
     return this.valueReader.readBoolean(JSON.parse(raw), visitor);
   }
 
-  readBuffer<R>(raw: string, visitor: ReadVisitor<R>): R {
-    return this.valueReader.readBuffer(JSON.parse(raw), visitor);
+  readBytes<R>(raw: string, visitor: ReadVisitor<R>): R {
+    return this.valueReader.readBytes(JSON.parse(raw), visitor);
   }
 
   readDate<R>(raw: string, visitor: ReadVisitor<R>): R {

--- a/src/lib/readers/json.ts
+++ b/src/lib/readers/json.ts
@@ -1,3 +1,7 @@
+/**
+ * @module kryo/readers/json
+ */
+
 import { Reader, ReadVisitor } from "../types";
 import { JsonValueReader } from "./json-value";
 

--- a/src/lib/readers/qs-value.ts
+++ b/src/lib/readers/qs-value.ts
@@ -3,8 +3,8 @@
  */
 
 import { Incident } from "incident";
+import { Reader, ReadVisitor } from "../core";
 import { createInvalidTypeError } from "../errors/invalid-type";
-import { Reader, ReadVisitor } from "../types";
 import { JsonReader } from "./json";
 
 export class QsValueReader implements Reader<any> {

--- a/src/lib/readers/qs-value.ts
+++ b/src/lib/readers/qs-value.ts
@@ -1,3 +1,7 @@
+/**
+ * @module kryo/readers/qs-value
+ */
+
 import { Incident } from "incident";
 import { createInvalidTypeError } from "../errors/invalid-type";
 import { Reader, ReadVisitor } from "../types";

--- a/src/lib/readers/qs-value.ts
+++ b/src/lib/readers/qs-value.ts
@@ -32,7 +32,7 @@ export class QsValueReader implements Reader<any> {
     return visitor.fromBoolean(input === "true");
   }
 
-  readBuffer<R>(input: any, visitor: ReadVisitor<R>): R {
+  readBytes<R>(input: any, visitor: ReadVisitor<R>): R {
     if (typeof input !== "string") {
       throw createInvalidTypeError("string", input);
     } else if (!/^(?:[0-9a-f]{2})*$/.test(input)) {
@@ -44,7 +44,7 @@ export class QsValueReader implements Reader<any> {
     for (let i: number = 0; i < len; i++) {
       result[i] = parseInt(input.substr(2 * i, 2), 16);
     }
-    return visitor.fromBuffer(result);
+    return visitor.fromBytes(result);
   }
 
   readDate<R>(input: any, visitor: ReadVisitor<R>): R {

--- a/src/lib/readers/qs.ts
+++ b/src/lib/readers/qs.ts
@@ -1,3 +1,7 @@
+/**
+ * @module kryo/readers/qs
+ */
+
 import _qs from "qs";
 import { Reader, ReadVisitor } from "../types";
 import { QsValueReader } from "./qs-value";

--- a/src/lib/readers/qs.ts
+++ b/src/lib/readers/qs.ts
@@ -3,7 +3,7 @@
  */
 
 import _qs from "qs";
-import { Reader, ReadVisitor } from "../types";
+import { Reader, ReadVisitor } from "../core";
 import { QsValueReader } from "./qs-value";
 
 export class QsReader implements Reader<string> {

--- a/src/lib/readers/qs.ts
+++ b/src/lib/readers/qs.ts
@@ -26,8 +26,8 @@ export class QsReader implements Reader<string> {
     return this.valueReader.readBoolean(this.qs.parse(raw)[this.primitiveWrapper], visitor);
   }
 
-  readBuffer<R>(raw: string, visitor: ReadVisitor<R>): R {
-    return this.valueReader.readBuffer(this.qs.parse(raw)[this.primitiveWrapper], visitor);
+  readBytes<R>(raw: string, visitor: ReadVisitor<R>): R {
+    return this.valueReader.readBytes(this.qs.parse(raw)[this.primitiveWrapper], visitor);
   }
 
   readDate<R>(raw: string, visitor: ReadVisitor<R>): R {

--- a/src/lib/readers/read-visitor.ts
+++ b/src/lib/readers/read-visitor.ts
@@ -4,8 +4,8 @@ function fromBoolean(input: boolean): never {
   throw new Error("Unable to read from boolean");
 }
 
-function fromBuffer(input: Uint8Array): never {
-  throw new Error("Unable to read from buffer");
+function fromBytes(input: Uint8Array): never {
+  throw new Error("Unable to read from bytes");
 }
 
 function fromDate(input: Date): never {
@@ -34,7 +34,7 @@ function fromString(input: string): never {
 
 export function readVisitor<R>(partial: Partial<ReadVisitor<R>>): ReadVisitor<R> {
   return {
-    fromBuffer,
+    fromBytes,
     fromBoolean,
     fromDate,
     fromFloat64,

--- a/src/lib/readers/read-visitor.ts
+++ b/src/lib/readers/read-visitor.ts
@@ -1,3 +1,7 @@
+/**
+ * @module kryo/readers/read-visitor
+ */
+
 import { ReadVisitor } from "../types";
 
 function fromBoolean(input: boolean): never {

--- a/src/lib/readers/read-visitor.ts
+++ b/src/lib/readers/read-visitor.ts
@@ -2,7 +2,7 @@
  * @module kryo/readers/read-visitor
  */
 
-import { ReadVisitor } from "../types";
+import { ReadVisitor } from "../core";
 
 function fromBoolean(input: boolean): never {
   throw new Error("Unable to read from boolean");

--- a/src/lib/test-error.ts
+++ b/src/lib/test-error.ts
@@ -1,0 +1,17 @@
+import { Type } from "./core";
+import { createInvalidValueError } from "./errors/invalid-value";
+
+/**
+ * Calls the `.testError` method of `type` or falls back to an implementation derived from `.test`.
+ *
+ * @param type The type used for the test.
+ * @param value The value to match.
+ * @return Undefined if the value matches, otherwise an `Error` instance.
+ */
+export function testError<T>(type: Type<T>, value: T): Error | undefined {
+  if (type.testError !== undefined) {
+    return type.testError(value);
+  } else {
+    return type.test(value) ? undefined : createInvalidValueError(type, value);
+  }
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -87,7 +87,7 @@ export interface Writer<W> {
 
   writeBoolean(value: boolean): W;
 
-  writeBuffer(value: Uint8Array): W;
+  writeBytes(value: Uint8Array): W;
 
   writeDate(value: Date): W;
 
@@ -114,7 +114,7 @@ export interface Writer<W> {
 export interface ReadVisitor<T> {
   fromBoolean(input: boolean): T;
 
-  fromBuffer(input: Uint8Array): T;
+  fromBytes(input: Uint8Array): T;
 
   fromDate(input: Date): T;
 
@@ -142,7 +142,7 @@ export interface Reader<R> {
 
   readBoolean<T>(raw: R, visitor: ReadVisitor<T>): T;
 
-  readBuffer<T>(raw: R, visitor: ReadVisitor<T>): T;
+  readBytes<T>(raw: R, visitor: ReadVisitor<T>): T;
 
   readDate<T>(raw: R, visitor: ReadVisitor<T>): T;
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -9,18 +9,53 @@
  */
 export type Lazy<T> = T | (() => T);
 
+/**
+ * Simple type interface.
+ *
+ * This is the smallest interface for objects to be valid types.
+ * A type with this interface can check the validity and equality of values, and clone them.
+ */
 export interface Type<T> {
-  // name: string;
+  /**
+   * Name of this type. This is only used to help with debugging.
+   */
+  name?: string;
 
-  testError(val: T): Error | undefined;
+  /**
+   * Tests if this type matches `value`, describes the error if not.
+   *
+   * @param value The value to test against this type.
+   * @return If this type matches `value` then `undefined`; otherwise an error describing why this
+   *         type does not match `value`.
+   */
+  testError(value: T): Error | undefined;
 
-  test(val: T): boolean;
+  /**
+   * Tests if this type matches `value`.
+   *
+   * @param value The value to test against this type.
+   * @return Boolean indicating if this type matches `value`.
+   */
+  test(value: T): boolean;
 
-  equals(val1: T, val2: T): boolean;
+  /**
+   * Tests if `left` is equal to `value`.
+   *
+   * This is a deep strict structural equality test restricted to the properties of this type.
+   *
+   * @param left Left value, trusted to be compatible with this type.
+   * @param right Right value, trusted to be compatible with this type.
+   * @return Boolean indicating if both values are equal.
+   */
+  equals(left: T, right: T): boolean;
 
-  clone(val: T): T;
-
-  toJSON(): any;
+  /**
+   * Returns a deep copy of `value`.
+   *
+   * @param value The value to clone, trusted to be compatible with this type.
+   * @return A deep copy of the supplied value, restricted to the properties of this type.
+   */
+  clone(value: T): T;
 
   write?<W>(writer: Writer<W>, value: T): W;
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,5 +1,7 @@
 /**
  * This module defines most of the Typescript interfaces and type aliases used by Kryo.
+ *
+ * @module kryo/types
  */
 
 /**
@@ -43,6 +45,15 @@ export interface Type<T> {
    *
    * This is a deep strict structural equality test restricted to the properties of this type.
    *
+   * It satisfies the following properties (the variables `a`, `b` and `c` are valid values):
+   * - Reflexivity: `type.equal(a, a) === true`
+   * - Symmetry: `type.equals(a, b) === type.equals(b, a)`
+   * - Transitivity: if `type.equals(a, b) && type.equals(b, c)` then `type.equals(a, c)`
+   *
+   * The above properties mean that type objects implement the `Setoid` algebra as specified by
+   * Static Land.
+   *
+   * @see https://github.com/rpominov/static-land/blob/master/docs/spec.md#setoid
    * @param left Left value, trusted to be compatible with this type.
    * @param right Right value, trusted to be compatible with this type.
    * @return Boolean indicating if both values are equal.

--- a/src/lib/types/any.ts
+++ b/src/lib/types/any.ts
@@ -1,17 +1,9 @@
-import { createNotImplementedError } from "../errors/not-implemented";
 import { IoType, Reader, Writer } from "../types";
 
-export namespace json {
-  export type Type = undefined;
-}
 export type Diff = any;
 
 export class AnyType<T = any> implements IoType<T> {
   constructor() {
-  }
-
-  toJSON(): json.Type {
-    throw createNotImplementedError("AnyType#toJSON");
   }
 
   read<R>(reader: Reader<R>, raw: R): T {

--- a/src/lib/types/any.ts
+++ b/src/lib/types/any.ts
@@ -1,4 +1,4 @@
-import { IoType, Reader, Writer } from "../types";
+import { IoType, Reader, Writer } from "../core";
 
 export type Diff = any;
 

--- a/src/lib/types/array.ts
+++ b/src/lib/types/array.ts
@@ -4,16 +4,11 @@ import { createInvalidArrayItemsError } from "../errors/invalid-array-items";
 import { createInvalidTypeError } from "../errors/invalid-type";
 import { createLazyOptionsError } from "../errors/lazy-options";
 import { createMaxArrayLengthError } from "../errors/max-array-length";
-import { createNotImplementedError } from "../errors/not-implemented";
 import { readVisitor } from "../readers/read-visitor";
 import { IoType, Lazy, Reader, Type, Writer } from "../types";
 
 export type Name = "array";
 export const name: Name = "array";
-export namespace json {
-  // TODO(demurgos): Export arrayType to JSON
-  export type Type = undefined;
-}
 export type Diff = any;
 
 /**
@@ -63,10 +58,6 @@ export const ArrayType: ArrayTypeConstructor = <any> class<T, M extends Type<T> 
     } else {
       lazyProperties(this, this._applyOptions, ["itemType", "maxLength"]);
     }
-  }
-
-  toJSON(): json.Type {
-    throw createNotImplementedError("ArrayType#toJSON");
   }
 
   // TODO: Dynamically add with prototype?

--- a/src/lib/types/array.ts
+++ b/src/lib/types/array.ts
@@ -3,9 +3,11 @@ import { lazyProperties } from "../_helpers/lazy-properties";
 import { IoType, Lazy, Reader, Type, Writer } from "../core";
 import { createInvalidArrayItemsError } from "../errors/invalid-array-items";
 import { createInvalidTypeError } from "../errors/invalid-type";
+import { createInvalidValueError } from "../errors/invalid-value";
 import { createLazyOptionsError } from "../errors/lazy-options";
 import { createMaxArrayLengthError } from "../errors/max-array-length";
 import { readVisitor } from "../readers/read-visitor";
+import { testError } from "../test-error";
 
 export type Name = "array";
 export const name: Name = "array";
@@ -105,17 +107,17 @@ export const ArrayType: ArrayTypeConstructor = <any> class<T, M extends Type<T> 
     });
   }
 
-  testError(val: T[]): Error | undefined {
-    if (!Array.isArray(val)) {
-      return createInvalidTypeError("array", val);
+  testError(value: T[]): Error | undefined {
+    if (!Array.isArray(value)) {
+      return createInvalidTypeError("array", value);
     }
-    if (this.maxLength !== undefined && val.length > this.maxLength) {
-      return createMaxArrayLengthError(val, this.maxLength);
+    if (this.maxLength !== undefined && value.length > this.maxLength) {
+      return createMaxArrayLengthError(value, this.maxLength);
     }
     const invalid: Map<number, Error> = new Map();
-    const itemCount: number = val.length;
+    const itemCount: number = value.length;
     for (let i: number = 0; i < itemCount; i++) {
-      const error: Error | undefined = this.itemType.testError(val[i]);
+      const error: Error | undefined = testError(this.itemType, value[i]);
       if (error !== undefined) {
         invalid.set(i, error);
       }

--- a/src/lib/types/array.ts
+++ b/src/lib/types/array.ts
@@ -1,11 +1,11 @@
 import { Incident } from "incident";
 import { lazyProperties } from "../_helpers/lazy-properties";
+import { IoType, Lazy, Reader, Type, Writer } from "../core";
 import { createInvalidArrayItemsError } from "../errors/invalid-array-items";
 import { createInvalidTypeError } from "../errors/invalid-type";
 import { createLazyOptionsError } from "../errors/lazy-options";
 import { createMaxArrayLengthError } from "../errors/max-array-length";
 import { readVisitor } from "../readers/read-visitor";
-import { IoType, Lazy, Reader, Type, Writer } from "../types";
 
 export type Name = "array";
 export const name: Name = "array";

--- a/src/lib/types/boolean.ts
+++ b/src/lib/types/boolean.ts
@@ -1,4 +1,4 @@
-import { IoType, Reader, VersionedType, Writer } from "../core";
+import { IoType, Ord, Reader, VersionedType, Writer } from "../core";
 import { createInvalidTypeError } from "../errors/invalid-type";
 import { readVisitor } from "../readers/read-visitor";
 
@@ -7,7 +7,7 @@ export const name: Name = "boolean";
 
 export type Diff = boolean;
 
-export class BooleanType implements IoType<boolean>, VersionedType<boolean, Diff> {
+export class BooleanType implements IoType<boolean>, VersionedType<boolean, Diff>, Ord<boolean> {
   readonly name: Name = name;
 
   // TODO: Dynamically add with prototype?
@@ -31,12 +31,16 @@ export class BooleanType implements IoType<boolean>, VersionedType<boolean, Diff
     return undefined;
   }
 
-  test(val: boolean): val is boolean {
-    return this.testError(val) === undefined;
+  test(value: boolean): value is boolean {
+    return typeof value === "boolean";
   }
 
-  equals(val1: boolean, val2: boolean): boolean {
-    return val1 === val2;
+  equals(left: boolean, right: boolean): boolean {
+    return left === right;
+  }
+
+  lte(left: boolean, right: boolean): boolean {
+    return left <= right;
   }
 
   clone(val: boolean): boolean {

--- a/src/lib/types/boolean.ts
+++ b/src/lib/types/boolean.ts
@@ -1,6 +1,6 @@
+import { IoType, Reader, VersionedType, Writer } from "../core";
 import { createInvalidTypeError } from "../errors/invalid-type";
 import { readVisitor } from "../readers/read-visitor";
-import { IoType, Reader, VersionedType, Writer } from "../types";
 
 export type Name = "boolean";
 export const name: Name = "boolean";

--- a/src/lib/types/boolean.ts
+++ b/src/lib/types/boolean.ts
@@ -10,11 +10,6 @@ export type Diff = boolean;
 export class BooleanType implements IoType<boolean>, VersionedType<boolean, Diff> {
   readonly name: Name = name;
 
-  toJSON(): undefined {
-    /* tslint:disable-next-line:return-undefined */
-    return undefined;
-  }
-
   // TODO: Dynamically add with prototype?
   read<R>(reader: Reader<R>, raw: R): boolean {
     return reader.readBoolean(raw, readVisitor({

--- a/src/lib/types/buffer.ts
+++ b/src/lib/types/buffer.ts
@@ -8,12 +8,6 @@ import { IoType, Lazy, Reader, VersionedType, Writer } from "../types";
 
 export type Name = "buffer";
 export const name: Name = "buffer";
-export namespace json {
-  export type Input = string;
-  export type Output = string;
-  // TODO(demurgos): Export bufferType to JSON
-  export type Type = undefined;
-}
 export type Diff = any;
 
 export interface BufferTypeOptions {
@@ -36,10 +30,6 @@ export class BufferType implements IoType<Uint8Array>, VersionedType<Uint8Array,
     } else {
       lazyProperties(this, this._applyOptions, ["maxLength"]);
     }
-  }
-
-  toJSON(): json.Type {
-    throw createNotImplementedError("BufferType#toJSON");
   }
 
   // TODO: Dynamically add with prototype?

--- a/src/lib/types/bytes.ts
+++ b/src/lib/types/bytes.ts
@@ -1,5 +1,5 @@
 import { lazyProperties } from "../_helpers/lazy-properties";
-import { IoType, Lazy, Reader, VersionedType, Writer } from "../core";
+import { IoType, Lazy, Ord, Reader, VersionedType, Writer } from "../core";
 import { createInvalidTypeError } from "../errors/invalid-type";
 import { createLazyOptionsError } from "../errors/lazy-options";
 import { createMaxArrayLengthError } from "../errors/max-array-length";
@@ -12,7 +12,7 @@ export interface BytesTypeOptions {
   maxLength: number;
 }
 
-export class BytesType implements IoType<Uint8Array>, VersionedType<Uint8Array, Diff> {
+export class BytesType implements IoType<Uint8Array>, VersionedType<Uint8Array, Diff>, Ord<Uint8Array> {
   readonly maxLength: number;
 
   private _options: Lazy<BytesTypeOptions>;
@@ -57,16 +57,26 @@ export class BytesType implements IoType<Uint8Array>, VersionedType<Uint8Array, 
     return this.testError(val) === undefined;
   }
 
-  equals(val1: Uint8Array, val2: Uint8Array): boolean {
-    if (val2.length !== val1.length) {
+  equals(left: Uint8Array, right: Uint8Array): boolean {
+    if (left.length !== right.length) {
       return false;
     }
-    for (let i: number = 0; i < val1.length; i++) {
-      if (val2[i] !== val1[i]) {
+    for (let i: number = 0; i < left.length; i++) {
+      if (left[i] !== right[i]) {
         return false;
       }
     }
     return true;
+  }
+
+  lte(left: Uint8Array, right: Uint8Array): boolean {
+    const minLength: number = Math.min(left.length, right.length);
+    for (let i: number = 0; i < minLength; i++) {
+      if (left[i] > right[i]) {
+        return false;
+      }
+    }
+    return left.length <= right.length;
   }
 
   clone(val: Uint8Array): Uint8Array {

--- a/src/lib/types/bytes.ts
+++ b/src/lib/types/bytes.ts
@@ -6,21 +6,18 @@ import { createNotImplementedError } from "../errors/not-implemented";
 import { readVisitor } from "../readers/read-visitor";
 import { IoType, Lazy, Reader, VersionedType, Writer } from "../types";
 
-export type Name = "buffer";
-export const name: Name = "buffer";
 export type Diff = any;
 
-export interface BufferTypeOptions {
+export interface BytesTypeOptions {
   maxLength: number;
 }
 
-export class BufferType implements IoType<Uint8Array>, VersionedType<Uint8Array, Diff> {
-  readonly name: Name = name;
+export class BytesType implements IoType<Uint8Array>, VersionedType<Uint8Array, Diff> {
   readonly maxLength: number;
 
-  private _options: Lazy<BufferTypeOptions>;
+  private _options: Lazy<BytesTypeOptions>;
 
-  constructor(options: Lazy<BufferTypeOptions>) {
+  constructor(options: Lazy<BytesTypeOptions>) {
     // TODO: Remove once TS 2.7 is better supported by editors
     this.maxLength = <any> undefined;
 
@@ -34,8 +31,8 @@ export class BufferType implements IoType<Uint8Array>, VersionedType<Uint8Array,
 
   // TODO: Dynamically add with prototype?
   read<R>(reader: Reader<R>, raw: R): Uint8Array {
-    return reader.readBuffer(raw, readVisitor({
-      fromBuffer(input: Uint8Array): Uint8Array {
+    return reader.readBytes(raw, readVisitor({
+      fromBytes(input: Uint8Array): Uint8Array {
         return input;
       },
     }));
@@ -43,7 +40,7 @@ export class BufferType implements IoType<Uint8Array>, VersionedType<Uint8Array,
 
   // TODO: Dynamically add with prototype?
   write<W>(writer: Writer<W>, value: Uint8Array): W {
-    return writer.writeBuffer(value);
+    return writer.writeBytes(value);
   }
 
   testError(val: Uint8Array): Error | undefined {
@@ -101,7 +98,7 @@ export class BufferType implements IoType<Uint8Array>, VersionedType<Uint8Array,
     if (this._options === undefined) {
       throw createLazyOptionsError(this);
     }
-    const options: BufferTypeOptions = typeof this._options === "function" ? this._options() : this._options;
+    const options: BytesTypeOptions = typeof this._options === "function" ? this._options() : this._options;
 
     const maxLength: number = options.maxLength;
 

--- a/src/lib/types/bytes.ts
+++ b/src/lib/types/bytes.ts
@@ -1,10 +1,10 @@
 import { lazyProperties } from "../_helpers/lazy-properties";
+import { IoType, Lazy, Reader, VersionedType, Writer } from "../core";
 import { createInvalidTypeError } from "../errors/invalid-type";
 import { createLazyOptionsError } from "../errors/lazy-options";
 import { createMaxArrayLengthError } from "../errors/max-array-length";
 import { createNotImplementedError } from "../errors/not-implemented";
 import { readVisitor } from "../readers/read-visitor";
-import { IoType, Lazy, Reader, VersionedType, Writer } from "../types";
 
 export type Diff = any;
 

--- a/src/lib/types/codepoint-string.ts
+++ b/src/lib/types/codepoint-string.ts
@@ -28,9 +28,6 @@ export enum Normalization {
 export type Name = "codepoint-string";
 export const name: Name = "codepoint-string";
 export namespace json {
-  export type Input = string;
-  export type Output = string;
-
   export interface Type {
     name: Name;
     normalization: "none" | "nfc";

--- a/src/lib/types/codepoint-string.ts
+++ b/src/lib/types/codepoint-string.ts
@@ -1,6 +1,7 @@
 import { Incident } from "incident";
 import { checkedUcs2Decode } from "../_helpers/checked-ucs2-decode";
 import { lazyProperties } from "../_helpers/lazy-properties";
+import { IoType, Lazy, Reader, VersionedType, Writer } from "../core";
 import { createInvalidTypeError } from "../errors/invalid-type";
 import { createLazyOptionsError } from "../errors/lazy-options";
 import { createLowerCaseError } from "../errors/lower-case";
@@ -10,7 +11,6 @@ import { createMissingDependencyError } from "../errors/missing-dependency";
 import { createNotTrimmedError } from "../errors/not-trimmed";
 import { createPatternNotMatchedError } from "../errors/pattern-not-matched";
 import { readVisitor } from "../readers/read-visitor";
-import { IoType, Lazy, Reader, VersionedType, Writer } from "../types";
 
 let unormNfc: ((str: string) => string) | undefined = undefined;
 try {

--- a/src/lib/types/custom.ts
+++ b/src/lib/types/custom.ts
@@ -1,6 +1,6 @@
 import { lazyProperties } from "../_helpers/lazy-properties";
+import { Lazy, Reader, Type, Writer } from "../core";
 import { createLazyOptionsError } from "../errors/lazy-options";
-import { Lazy, Reader, Type, Writer } from "../types";
 
 export type Name = "custom";
 export const name: Name = "custom";

--- a/src/lib/types/custom.ts
+++ b/src/lib/types/custom.ts
@@ -1,6 +1,5 @@
 import { lazyProperties } from "../_helpers/lazy-properties";
 import { createLazyOptionsError } from "../errors/lazy-options";
-import { createNotImplementedError } from "../errors/not-implemented";
 import { Lazy, Reader, Type, Writer } from "../types";
 
 export type Name = "custom";
@@ -44,10 +43,6 @@ export class CustomType<T> implements Type<T> {
     } else {
       lazyProperties(this, this._applyOptions, ["read", "write", "testError", "equals", "clone"]);
     }
-  }
-
-  toJSON(): never {
-    throw createNotImplementedError("CustomType#toJSON");
   }
 
   test(val: T): boolean {

--- a/src/lib/types/date.ts
+++ b/src/lib/types/date.ts
@@ -5,22 +5,10 @@ import { IoType, Reader, VersionedType, Writer } from "../types";
 
 export type Name = "date";
 export const name: Name = "date";
-export namespace json {
-  export type Input = string | number;
-  export type Output = string;
-
-  export interface Type {
-    name: Name;
-  }
-}
 export type Diff = number;
 
 export class DateType implements IoType<Date>, VersionedType<Date, Diff> {
   readonly name: Name = name;
-
-  toJSON(): json.Type {
-    return {name};
-  }
 
   // TODO: Dynamically add with prototype?
   read<R>(reader: Reader<R>, raw: R): Date {

--- a/src/lib/types/date.ts
+++ b/src/lib/types/date.ts
@@ -1,7 +1,7 @@
+import { IoType, Reader, VersionedType, Writer } from "../core";
 import { createInvalidTimestampError } from "../errors/invalid-timestamp";
 import { createInvalidTypeError } from "../errors/invalid-type";
 import { readVisitor } from "../readers/read-visitor";
-import { IoType, Reader, VersionedType, Writer } from "../types";
 
 export type Name = "date";
 export const name: Name = "date";

--- a/src/lib/types/date.ts
+++ b/src/lib/types/date.ts
@@ -1,4 +1,4 @@
-import { IoType, Reader, VersionedType, Writer } from "../core";
+import { IoType, Ord, Reader, VersionedType, Writer } from "../core";
 import { createInvalidTimestampError } from "../errors/invalid-timestamp";
 import { createInvalidTypeError } from "../errors/invalid-type";
 import { readVisitor } from "../readers/read-visitor";
@@ -7,7 +7,7 @@ export type Name = "date";
 export const name: Name = "date";
 export type Diff = number;
 
-export class DateType implements IoType<Date>, VersionedType<Date, Diff> {
+export class DateType implements IoType<Date>, VersionedType<Date, Diff>, Ord<Date> {
   readonly name: Name = name;
 
   // TODO: Dynamically add with prototype?
@@ -44,8 +44,12 @@ export class DateType implements IoType<Date>, VersionedType<Date, Diff> {
     return this.testError(val) === undefined;
   }
 
-  equals(val1: Date, val2: Date): boolean {
-    return val1.getTime() === val2.getTime();
+  equals(left: Date, right: Date): boolean {
+    return left.getTime() === right.getTime();
+  }
+
+  lte(left: Date, right: Date): boolean {
+    return left.getTime() <= right.getTime();
   }
 
   clone(val: Date): Date {
@@ -53,17 +57,17 @@ export class DateType implements IoType<Date>, VersionedType<Date, Diff> {
   }
 
   diff(oldVal: Date, newVal: Date): Diff | undefined {
-    /* tslint:disable-next-line:strict-boolean-expressions */
+    // tslint:disable-next-line:strict-boolean-expressions
     return newVal.getTime() - oldVal.getTime() || undefined;
   }
 
   patch(oldVal: Date, diff: Diff | undefined): Date {
-    /* tslint:disable-next-line:strict-boolean-expressions */
+    // tslint:disable-next-line:strict-boolean-expressions
     return new Date(oldVal.getTime() + (diff || 0));
   }
 
   reverseDiff(diff: Diff | undefined): Diff | undefined {
-    /* tslint:disable-next-line:strict-boolean-expressions */
+    // tslint:disable-next-line:strict-boolean-expressions
     return diff && -diff;
   }
 

--- a/src/lib/types/document.ts
+++ b/src/lib/types/document.ts
@@ -10,11 +10,6 @@ import { IoType, Lazy, Reader, Type, VersionedType, Writer } from "../types";
 
 export type Name = "document";
 export const name: Name = "document";
-export namespace json {
-  export interface Type {
-    name: Name;
-  }
-}
 
 export interface Diff<T> {
   set: {[P in keyof T]?: any}; // val
@@ -130,14 +125,6 @@ export const DocumentType: DocumentTypeConstructor = class<T extends {}> impleme
       }
     }
     return this._outKeys;
-  }
-
-  static fromJSON(options: json.Type): DocumentType<{}> {
-    throw createNotImplementedError("DocumentType.fromJSON");
-  }
-
-  toJSON(): json.Type {
-    throw createNotImplementedError("DocumentType#toJSON");
   }
 
   getOutKey(key: keyof T): string {

--- a/src/lib/types/document.ts
+++ b/src/lib/types/document.ts
@@ -1,12 +1,12 @@
 import { Incident } from "incident";
 import { lazyProperties } from "../_helpers/lazy-properties";
 import { CaseStyle, rename } from "../case-style";
+import { IoType, Lazy, Reader, Type, VersionedType, Writer } from "../core";
 import { createInvalidDocumentError } from "../errors/invalid-document";
 import { createInvalidTypeError } from "../errors/invalid-type";
 import { createLazyOptionsError } from "../errors/lazy-options";
 import { createNotImplementedError } from "../errors/not-implemented";
 import { readVisitor } from "../readers/read-visitor";
-import { IoType, Lazy, Reader, Type, VersionedType, Writer } from "../types";
 
 export type Name = "document";
 export const name: Name = "document";

--- a/src/lib/types/float64.ts
+++ b/src/lib/types/float64.ts
@@ -1,9 +1,9 @@
 import { lazyProperties } from "../_helpers/lazy-properties";
+import { IoType, Lazy, Reader, VersionedType, Writer } from "../core";
 import { createInvalidFloat64Error } from "../errors/invalid-float64";
 import { createInvalidTypeError } from "../errors/invalid-type";
 import { createLazyOptionsError } from "../errors/lazy-options";
 import { readVisitor } from "../readers/read-visitor";
-import { IoType, Lazy, Reader, VersionedType, Writer } from "../types";
 
 export type Name = "float64";
 export const name: Name = "float64";

--- a/src/lib/types/integer.ts
+++ b/src/lib/types/integer.ts
@@ -9,9 +9,6 @@ import { IoType, Lazy, Reader, VersionedType, Writer } from "../types";
 export type Name = "integer";
 export const name: Name = "integer";
 export namespace json {
-  export type Input = number;
-  export type Output = number;
-
   export interface Type {
     name: Name;
     min: number;

--- a/src/lib/types/integer.ts
+++ b/src/lib/types/integer.ts
@@ -1,10 +1,10 @@
 import { Incident } from "incident";
 import { lazyProperties } from "../_helpers/lazy-properties";
+import { IoType, Lazy, Reader, VersionedType, Writer } from "../core";
 import { createInvalidIntegerError } from "../errors/invalid-integer";
 import { createInvalidTypeError } from "../errors/invalid-type";
 import { createLazyOptionsError } from "../errors/lazy-options";
 import { readVisitor } from "../readers/read-visitor";
-import { IoType, Lazy, Reader, VersionedType, Writer } from "../types";
 
 export type Name = "integer";
 export const name: Name = "integer";

--- a/src/lib/types/integer.ts
+++ b/src/lib/types/integer.ts
@@ -1,6 +1,6 @@
 import { Incident } from "incident";
 import { lazyProperties } from "../_helpers/lazy-properties";
-import { IoType, Lazy, Reader, VersionedType, Writer } from "../core";
+import { IoType, Lazy, Ord, Reader, VersionedType, Writer } from "../core";
 import { createInvalidIntegerError } from "../errors/invalid-integer";
 import { createInvalidTypeError } from "../errors/invalid-type";
 import { createLazyOptionsError } from "../errors/lazy-options";
@@ -44,7 +44,7 @@ export const DEFAULT_MIN: number = Number.MIN_SAFE_INTEGER - 1;
  */
 export const DEFAULT_MAX: number = Number.MAX_SAFE_INTEGER;
 
-export class IntegerType implements IoType<number>, VersionedType<number, Diff> {
+export class IntegerType implements IoType<number>, VersionedType<number, Diff>, Ord<number> {
 
   readonly name: Name = name;
   readonly min: number;
@@ -112,8 +112,12 @@ export class IntegerType implements IoType<number>, VersionedType<number, Diff> 
     return typeof val === "number" && val >= this.min && val <= this.max && Math.round(val) === val;
   }
 
-  equals(val1: number, val2: number): boolean {
-    return val1 === val2;
+  equals(left: number, right: number): boolean {
+    return left === right;
+  }
+
+  lte(left: number, right: number): boolean {
+    return left <= right;
   }
 
   clone(val: number): number {

--- a/src/lib/types/literal.ts
+++ b/src/lib/types/literal.ts
@@ -1,8 +1,8 @@
 import { Incident } from "incident";
 import { lazyProperties } from "../_helpers/lazy-properties";
+import { IoType, Lazy, Reader, Type, Writer } from "../core";
 import { createLazyOptionsError } from "../errors/lazy-options";
 import { createNotImplementedError } from "../errors/not-implemented";
-import { IoType, Lazy, Reader, Type, Writer } from "../types";
 
 export type Name = "literal";
 export const name: Name = "literal";

--- a/src/lib/types/literal.ts
+++ b/src/lib/types/literal.ts
@@ -6,9 +6,6 @@ import { IoType, Lazy, Reader, Type, Writer } from "../types";
 
 export type Name = "literal";
 export const name: Name = "literal";
-export namespace json {
-  export type Type = undefined;
-}
 export type Diff = any;
 
 /**
@@ -61,10 +58,6 @@ export const LiteralType: LiteralTypeConstructor = class<T, M extends Type<T> = 
     } else {
       lazyProperties(this, this._applyOptions, ["type", "value"]);
     }
-  }
-
-  toJSON(): json.Type {
-    throw createNotImplementedError("LiteralType#toJSON");
   }
 
   read<R>(reader: Reader<R>, raw: R): T {

--- a/src/lib/types/literal.ts
+++ b/src/lib/types/literal.ts
@@ -3,6 +3,7 @@ import { lazyProperties } from "../_helpers/lazy-properties";
 import { IoType, Lazy, Reader, Type, Writer } from "../core";
 import { createLazyOptionsError } from "../errors/lazy-options";
 import { createNotImplementedError } from "../errors/not-implemented";
+import { testError } from "../test-error";
 
 export type Name = "literal";
 export const name: Name = "literal";
@@ -75,7 +76,7 @@ export const LiteralType: LiteralTypeConstructor = class<T, M extends Type<T> = 
   }
 
   testError(val: T): Error | undefined {
-    const error: Error | undefined = this.type.testError(val);
+    const error: Error | undefined = testError(this.type, val);
     if (error !== undefined) {
       return error;
     }
@@ -85,8 +86,8 @@ export const LiteralType: LiteralTypeConstructor = class<T, M extends Type<T> = 
     return undefined;
   }
 
-  test(val: T): boolean {
-    return this.testError(val) === undefined;
+  test(value: T): boolean {
+    return this.type.test(value) && this.type.equals(value, this.value);
   }
 
   equals(val1: T, val2: T): boolean {

--- a/src/lib/types/map.ts
+++ b/src/lib/types/map.ts
@@ -8,18 +8,6 @@ import { IoType, Lazy, Reader, VersionedType, Writer } from "../types";
 
 export type Name = "map";
 export const name: Name = "map";
-export namespace json {
-  export interface Input {
-    [key: string]: any;
-  }
-
-  export interface Output {
-    [key: string]: any;
-  }
-
-  // TODO(demurgos): Export arrayType to JSON
-  export type Type = undefined;
-}
 export type Diff = any;
 
 export interface MapTypeOptions<K, V> {
@@ -51,10 +39,6 @@ export class MapType<K, V> implements IoType<Map<K, V>>, VersionedType<Map<K, V>
     } else {
       lazyProperties(this, this._applyOptions, ["keyType", "valueType", "maxSize", "assumeStringKey"]);
     }
-  }
-
-  toJSON(): json.Type {
-    throw createNotImplementedError("MapType#toJSON");
   }
 
   // TODO: Dynamically add with prototype?

--- a/src/lib/types/map.ts
+++ b/src/lib/types/map.ts
@@ -1,10 +1,10 @@
 import { Incident } from "incident";
 import { lazyProperties } from "../_helpers/lazy-properties";
+import { IoType, Lazy, Reader, VersionedType, Writer } from "../core";
 import { createInvalidTypeError } from "../errors/invalid-type";
 import { createLazyOptionsError } from "../errors/lazy-options";
 import { createNotImplementedError } from "../errors/not-implemented";
 import { readVisitor } from "../readers/read-visitor";
-import { IoType, Lazy, Reader, VersionedType, Writer } from "../types";
 
 export type Name = "map";
 export const name: Name = "map";

--- a/src/lib/types/null.ts
+++ b/src/lib/types/null.ts
@@ -4,21 +4,9 @@ import { IoType, Reader, VersionedType, Writer } from "../types";
 
 export type Name = "null";
 export const name: Name = "null";
-export namespace json {
-  export type Input = null;
-  export type Output = null;
-
-  export interface Type {
-    name: Name;
-  }
-}
 
 export class NullType implements IoType<null>, VersionedType<null, undefined> {
   readonly name: Name = name;
-
-  toJSON(): json.Type {
-    return {name};
-  }
 
   read<R>(reader: Reader<R>, raw: R): null {
     return reader.readNull(raw, readVisitor({

--- a/src/lib/types/null.ts
+++ b/src/lib/types/null.ts
@@ -1,6 +1,6 @@
+import { IoType, Reader, VersionedType, Writer } from "../core";
 import { createInvalidTypeError } from "../errors/invalid-type";
 import { readVisitor } from "../readers/read-visitor";
-import { IoType, Reader, VersionedType, Writer } from "../types";
 
 export type Name = "null";
 export const name: Name = "null";

--- a/src/lib/types/tagged-union.ts
+++ b/src/lib/types/tagged-union.ts
@@ -1,10 +1,10 @@
 import { Incident } from "incident";
 import { lazyProperties } from "../_helpers/lazy-properties";
+import { IoType, Lazy, Reader, VersionedType, Writer } from "../core";
 import { createInvalidTypeError } from "../errors/invalid-type";
 import { createLazyOptionsError } from "../errors/lazy-options";
 import { createNotImplementedError } from "../errors/not-implemented";
 import { readVisitor } from "../readers/read-visitor";
-import { IoType, Lazy, Reader, VersionedType, Writer } from "../types";
 import { DocumentType } from "./document";
 import { LiteralType } from "./literal";
 import { TsEnumType } from "./ts-enum";

--- a/src/lib/types/tagged-union.ts
+++ b/src/lib/types/tagged-union.ts
@@ -5,6 +5,7 @@ import { createInvalidTypeError } from "../errors/invalid-type";
 import { createLazyOptionsError } from "../errors/lazy-options";
 import { createNotImplementedError } from "../errors/not-implemented";
 import { readVisitor } from "../readers/read-visitor";
+import { testError } from "../test-error";
 import { DocumentType } from "./document";
 import { LiteralType } from "./literal";
 import { TsEnumType } from "./ts-enum";
@@ -113,7 +114,7 @@ export class TaggedUnionType<T extends {}, M extends DocumentType<T> = DocumentT
     if (variant === undefined) {
       return new Incident("UnknownUnionVariant", "Unknown union variant");
     }
-    return variant.testError(value);
+    return testError(variant, value);
   }
 
   // testWithVariant(val: T): TestWithVariantResult<T> {

--- a/src/lib/types/tagged-union.ts
+++ b/src/lib/types/tagged-union.ts
@@ -11,9 +11,6 @@ import { TsEnumType } from "./ts-enum";
 
 export type Name = "union";
 export const name: Name = "union";
-export namespace json {
-  export type Type = undefined;
-}
 export type Diff = any;
 
 export interface TaggedUnionTypeOptions<T extends {}, M extends DocumentType<T> = DocumentType<T>> {
@@ -54,10 +51,6 @@ export class TaggedUnionType<T extends {}, M extends DocumentType<T> = DocumentT
         ["variants", "tag"],
       );
     }
-  }
-
-  toJSON(): json.Type {
-    throw createNotImplementedError("UnionType#toJSON");
   }
 
   match(value: T): M | undefined {

--- a/src/lib/types/try-union.ts
+++ b/src/lib/types/try-union.ts
@@ -2,6 +2,7 @@ import { Incident } from "incident";
 import { lazyProperties } from "../_helpers/lazy-properties";
 import { IoType, Lazy, Reader, Type, VersionedType, Writer } from "../core";
 import { createLazyOptionsError } from "../errors/lazy-options";
+import { testError } from "../test-error";
 
 export type Name = "union";
 export const name: Name = "union";
@@ -81,7 +82,7 @@ export class TryUnionType<T, M extends Type<T> = Type<T>> implements IoType<T>, 
     if (variant === undefined) {
       return new Incident("UnknownUnionVariant", "Unknown union variant");
     }
-    return variant.testError(value);
+    return testError(variant, value);
   }
 
   test(val: T): boolean {

--- a/src/lib/types/try-union.ts
+++ b/src/lib/types/try-union.ts
@@ -1,14 +1,10 @@
 import { Incident } from "incident";
 import { lazyProperties } from "../_helpers/lazy-properties";
 import { createLazyOptionsError } from "../errors/lazy-options";
-import { createNotImplementedError } from "../errors/not-implemented";
 import { IoType, Lazy, Reader, Type, VersionedType, Writer } from "../types";
 
 export type Name = "union";
 export const name: Name = "union";
-export namespace json {
-  export type Type = undefined;
-}
 export type Diff = any;
 
 export interface TryUnionTypeOptions<T, M extends Type<T> = Type<T>> {
@@ -39,10 +35,6 @@ export class TryUnionType<T, M extends Type<T> = Type<T>> implements IoType<T>, 
         ["variants"],
       );
     }
-  }
-
-  toJSON(): json.Type {
-    throw createNotImplementedError("UnionType#toJSON");
   }
 
   match(value: T): M | undefined {

--- a/src/lib/types/try-union.ts
+++ b/src/lib/types/try-union.ts
@@ -1,7 +1,7 @@
 import { Incident } from "incident";
 import { lazyProperties } from "../_helpers/lazy-properties";
+import { IoType, Lazy, Reader, Type, VersionedType, Writer } from "../core";
 import { createLazyOptionsError } from "../errors/lazy-options";
-import { IoType, Lazy, Reader, Type, VersionedType, Writer } from "../types";
 
 export type Name = "union";
 export const name: Name = "union";

--- a/src/lib/types/ts-enum.ts
+++ b/src/lib/types/ts-enum.ts
@@ -14,12 +14,6 @@ export type SimpleEnum<EnumConstructor> = {[K in keyof EnumConstructor]: EnumCon
 
 export type Name = "simple-enum";
 export const name: Name = "simple-enum";
-export namespace json {
-  export interface Type {
-    name: Name;
-    enum: any;
-  }
-}
 export type Diff = number;
 
 export type EnumObject<EO, E extends number | string> = Record<keyof EO, E>;
@@ -153,11 +147,7 @@ export class TsEnumType<E extends string | number, EO extends {} = {}> implement
   }
 
   static fromJSON(): TsEnumType<any> {
-    throw createNotImplementedError("SimpleEnumType.fromJSON");
-  }
-
-  toJSON(): json.Type {
-    throw createNotImplementedError("SimpleEnumType#toJSON");
+    throw createNotImplementedError("TsEnumType.fromJSON");
   }
 
   read<R>(reader: Reader<R>, raw: R): E {

--- a/src/lib/types/ts-enum.ts
+++ b/src/lib/types/ts-enum.ts
@@ -1,11 +1,11 @@
 import { Incident } from "incident";
 import { lazyProperties } from "../_helpers/lazy-properties";
 import { CaseStyle, rename } from "../case-style";
+import { IoType, Lazy, Reader, Writer } from "../core";
 import { createInvalidTypeError } from "../errors/invalid-type";
 import { createLazyOptionsError } from "../errors/lazy-options";
 import { createNotImplementedError } from "../errors/not-implemented";
 import { readVisitor } from "../readers/read-visitor";
-import { IoType, Lazy, Reader, Writer } from "../types";
 
 /**
  * Represents an enum value defined in `EnumConstructor`

--- a/src/lib/types/ucs2-string.ts
+++ b/src/lib/types/ucs2-string.ts
@@ -1,5 +1,6 @@
 import { Incident } from "incident";
 import { lazyProperties } from "../_helpers/lazy-properties";
+import { IoType, Lazy, Reader, VersionedType, Writer } from "../core";
 import { createInvalidTypeError } from "../errors/invalid-type";
 import { createLazyOptionsError } from "../errors/lazy-options";
 import { createLowerCaseError } from "../errors/lower-case";
@@ -8,7 +9,6 @@ import { createMinUcs2StringLengthError } from "../errors/min-ucs2-string-length
 import { createNotTrimmedError } from "../errors/not-trimmed";
 import { createPatternNotMatchedError } from "../errors/pattern-not-matched";
 import { readVisitor } from "../readers/read-visitor";
-import { IoType, Lazy, Reader, VersionedType, Writer } from "../types";
 
 export type Name = "ucs2-string";
 export const name: Name = "ucs2-string";

--- a/src/lib/types/white-list.ts
+++ b/src/lib/types/white-list.ts
@@ -6,14 +6,6 @@ import { IoType, Lazy, Reader, VersionedType, Writer } from "../types";
 
 export type Name = "white-list";
 export const name: Name = "white-list";
-export namespace json {
-  export type Input = any;
-  export type Output = any;
-
-  export interface Type {
-    name: Name;
-  }
-}
 export type Diff = [number, number];
 
 export interface WhiteListTypeOptions<T> {
@@ -39,14 +31,6 @@ export class WhiteListType<T> implements IoType<T>, VersionedType<T, Diff> {
     } else {
       lazyProperties(this, this._applyOptions, ["itemType", "values"]);
     }
-  }
-
-  static fromJSON(options: json.Type): WhiteListType<any> {
-    throw createNotImplementedError("WhiteListType.fromJSON");
-  }
-
-  toJSON(): json.Type {
-    throw createNotImplementedError("TypedUnionType#toJSON");
   }
 
   read<R>(reader: Reader<R>, raw: R): T {

--- a/src/lib/types/white-list.ts
+++ b/src/lib/types/white-list.ts
@@ -1,8 +1,8 @@
 import { Incident } from "incident";
 import { lazyProperties } from "../_helpers/lazy-properties";
+import { IoType, Lazy, Reader, VersionedType, Writer } from "../core";
 import { createLazyOptionsError } from "../errors/lazy-options";
 import { createNotImplementedError } from "../errors/not-implemented";
-import { IoType, Lazy, Reader, VersionedType, Writer } from "../types";
 
 export type Name = "white-list";
 export const name: Name = "white-list";

--- a/src/lib/writers/bson-value.ts
+++ b/src/lib/writers/bson-value.ts
@@ -1,3 +1,7 @@
+/**
+ * @module kryo/writers/bson-value
+ */
+
 import bson from "bson";
 import { Writer } from "../types";
 import { JsonWriter } from "./json";

--- a/src/lib/writers/bson-value.ts
+++ b/src/lib/writers/bson-value.ts
@@ -3,7 +3,7 @@
  */
 
 import bson from "bson";
-import { Writer } from "../types";
+import { Writer } from "../core";
 import { JsonWriter } from "./json";
 import { StructuredWriter } from "./structured";
 

--- a/src/lib/writers/bson-value.ts
+++ b/src/lib/writers/bson-value.ts
@@ -23,7 +23,7 @@ export class BsonValueWriter extends StructuredWriter {
     return null;
   }
 
-  writeBuffer(value: Uint8Array): bson.Binary {
+  writeBytes(value: Uint8Array): bson.Binary {
     // TODO: Update Node type definitions
     return new this.bsonLib.Binary(Buffer.from(value as any));
   }

--- a/src/lib/writers/bson.ts
+++ b/src/lib/writers/bson.ts
@@ -22,8 +22,8 @@ export class BsonWriter implements Writer<Buffer> {
     return this.bsonSerializer.serialize({[this.primitiveWrapper]: this.valueWriter.writeBoolean(value)});
   }
 
-  writeBuffer(value: Uint8Array): Buffer {
-    return this.bsonSerializer.serialize({[this.primitiveWrapper]: this.valueWriter.writeBuffer(value)});
+  writeBytes(value: Uint8Array): Buffer {
+    return this.bsonSerializer.serialize({[this.primitiveWrapper]: this.valueWriter.writeBytes(value)});
   }
 
   writeDate(value: Date): Buffer {

--- a/src/lib/writers/bson.ts
+++ b/src/lib/writers/bson.ts
@@ -3,7 +3,7 @@
  */
 
 import _bson from "bson";
-import { Writer } from "../types";
+import { Writer } from "../core";
 import { BsonValueWriter } from "./bson-value";
 
 export class BsonWriter implements Writer<Buffer> {

--- a/src/lib/writers/bson.ts
+++ b/src/lib/writers/bson.ts
@@ -1,3 +1,7 @@
+/**
+ * @module kryo/writers/bson
+ */
+
 import _bson from "bson";
 import { Writer } from "../types";
 import { BsonValueWriter } from "./bson-value";

--- a/src/lib/writers/json-stream.ts
+++ b/src/lib/writers/json-stream.ts
@@ -25,7 +25,7 @@ export class JsonStreamWriter implements Writer<boolean> {
     return this.stream.write(value ? "true" : "false");
   }
 
-  writeBuffer(value: Uint8Array): boolean {
+  writeBytes(value: Uint8Array): boolean {
     const result: string[] = new Array(value.length);
     const len: number = value.length;
     for (let i: number = 0; i < len; i++) {

--- a/src/lib/writers/json-stream.ts
+++ b/src/lib/writers/json-stream.ts
@@ -1,3 +1,7 @@
+/**
+ * @module kryo/writers/json-stream
+ */
+
 import { Writer } from "../types";
 
 export interface WritableStream {

--- a/src/lib/writers/json-stream.ts
+++ b/src/lib/writers/json-stream.ts
@@ -2,7 +2,7 @@
  * @module kryo/writers/json-stream
  */
 
-import { Writer } from "../types";
+import { Writer } from "../core";
 
 export interface WritableStream {
   /**

--- a/src/lib/writers/json-value.ts
+++ b/src/lib/writers/json-value.ts
@@ -1,3 +1,7 @@
+/**
+ * @module kryo/writers/json-value
+ */
+
 import { Writer } from "../types";
 import { StructuredWriter } from "./structured";
 

--- a/src/lib/writers/json-value.ts
+++ b/src/lib/writers/json-value.ts
@@ -2,7 +2,7 @@
  * @module kryo/writers/json-value
  */
 
-import { Writer } from "../types";
+import { Writer } from "../core";
 import { StructuredWriter } from "./structured";
 
 export class JsonValueWriter extends StructuredWriter {

--- a/src/lib/writers/json-value.ts
+++ b/src/lib/writers/json-value.ts
@@ -23,7 +23,7 @@ export class JsonValueWriter extends StructuredWriter {
     return null;
   }
 
-  writeBuffer(value: Uint8Array): string {
+  writeBytes(value: Uint8Array): string {
     const result: string[] = new Array(value.length);
     const len: number = value.length;
     for (let i: number = 0; i < len; i++) {

--- a/src/lib/writers/json.ts
+++ b/src/lib/writers/json.ts
@@ -16,8 +16,8 @@ export class JsonWriter implements Writer<string> {
     return JSON.stringify(this.valueWriter.writeBoolean(value));
   }
 
-  writeBuffer(value: Uint8Array): string {
-    return JSON.stringify(this.valueWriter.writeBuffer(value));
+  writeBytes(value: Uint8Array): string {
+    return JSON.stringify(this.valueWriter.writeBytes(value));
   }
 
   writeDate(value: Date): string {

--- a/src/lib/writers/json.ts
+++ b/src/lib/writers/json.ts
@@ -1,3 +1,7 @@
+/**
+ * @module kryo/writers/json
+ */
+
 import { Writer } from "../types";
 import { JsonValueWriter } from "./json-value";
 

--- a/src/lib/writers/json.ts
+++ b/src/lib/writers/json.ts
@@ -2,7 +2,7 @@
  * @module kryo/writers/json
  */
 
-import { Writer } from "../types";
+import { Writer } from "../core";
 import { JsonValueWriter } from "./json-value";
 
 export class JsonWriter implements Writer<string> {

--- a/src/lib/writers/qs-value.ts
+++ b/src/lib/writers/qs-value.ts
@@ -1,3 +1,7 @@
+/**
+ * @module kryo/writers/qs-value
+ */
+
 import { Writer } from "../types";
 import { JsonWriter } from "./json";
 import { StructuredWriter } from "./structured";

--- a/src/lib/writers/qs-value.ts
+++ b/src/lib/writers/qs-value.ts
@@ -7,7 +7,7 @@ export class QsValueWriter extends StructuredWriter {
     return value ? "true" : "false";
   }
 
-  writeBuffer(value: Uint8Array): string {
+  writeBytes(value: Uint8Array): string {
     const result: string[] = new Array(value.length);
     const len: number = value.length;
     for (let i: number = 0; i < len; i++) {

--- a/src/lib/writers/qs-value.ts
+++ b/src/lib/writers/qs-value.ts
@@ -2,7 +2,7 @@
  * @module kryo/writers/qs-value
  */
 
-import { Writer } from "../types";
+import { Writer } from "../core";
 import { JsonWriter } from "./json";
 import { StructuredWriter } from "./structured";
 

--- a/src/lib/writers/qs.ts
+++ b/src/lib/writers/qs.ts
@@ -3,7 +3,7 @@
  */
 
 import _qs from "qs";
-import { Writer } from "../types";
+import { Writer } from "../core";
 import { QsValueWriter } from "./qs-value";
 
 export class QsWriter implements Writer<string> {

--- a/src/lib/writers/qs.ts
+++ b/src/lib/writers/qs.ts
@@ -1,3 +1,7 @@
+/**
+ * @module kryo/writers/qs
+ */
+
 import _qs from "qs";
 import { Writer } from "../types";
 import { QsValueWriter } from "./qs-value";

--- a/src/lib/writers/qs.ts
+++ b/src/lib/writers/qs.ts
@@ -21,8 +21,8 @@ export class QsWriter implements Writer<string> {
     return this.qs.stringify({[this.primitiveWrapper]: this.valueWriter.writeBoolean(value)});
   }
 
-  writeBuffer(value: Uint8Array): string {
-    return this.qs.stringify({[this.primitiveWrapper]: this.valueWriter.writeBuffer(value)});
+  writeBytes(value: Uint8Array): string {
+    return this.qs.stringify({[this.primitiveWrapper]: this.valueWriter.writeBytes(value)});
   }
 
   writeDate(value: Date): string {

--- a/src/lib/writers/structured.ts
+++ b/src/lib/writers/structured.ts
@@ -2,7 +2,7 @@
  * @module kryo/writers/structured
  */
 
-import { Writer } from "../types";
+import { Writer } from "../core";
 
 /**
  * Base class for `json`, `qs` and `bson` writers.

--- a/src/lib/writers/structured.ts
+++ b/src/lib/writers/structured.ts
@@ -1,3 +1,7 @@
+/**
+ * @module kryo/writers/structured
+ */
+
 import { Writer } from "../types";
 
 /**

--- a/src/lib/writers/structured.ts
+++ b/src/lib/writers/structured.ts
@@ -12,7 +12,7 @@ export abstract class StructuredWriter implements Writer<any> {
 
   abstract writeString(value: string): any;
 
-  abstract writeBuffer(value: Uint8Array): any;
+  abstract writeBytes(value: Uint8Array): any;
 
   abstract writeNull(): any;
 

--- a/src/test/helpers/test.ts
+++ b/src/test/helpers/test.ts
@@ -45,25 +45,29 @@ function getName(namedValue: NamedValue) {
   return "name" in namedValue ? namedValue.name : JSON.stringify(namedValue.value);
 }
 
-export function testInvalidValueSync(type: Type<any>, item: InvalidTypedValue) {
-  it("Should return an Error for .testErrorSync", function () {
-    chai.assert.instanceOf(type.testError(item.value), Error);
-  });
+export function testInvalidValue(type: Type<any>, item: InvalidTypedValue) {
+  if (type.testError !== undefined) {
+    it("Should return an Error for .testError", function () {
+      chai.assert.instanceOf(type.testError!(item.value), Error);
+    });
+  }
 
-  it("Should return `false` for .testSync", function () {
+  it("Should return `false` for .test", function () {
     chai.assert.isFalse(type.test(item.value));
   });
 }
 
-export function testValidValueSync(type: Type<any>, item: ValidTypedValue) {
-  it("Should return `undefined` for .testErrorSync", function () {
-    const error: Error | undefined = type.testError(item.value);
-    if (error !== undefined) {
-      chai.assert.fail(error, undefined, String(error));
-    }
-  });
+export function testValidValue(type: Type<any>, item: ValidTypedValue) {
+  if (type.testError !== undefined) {
+    it("Should return `undefined` for .testError", function () {
+      const error: Error | undefined = type.testError!(item.value);
+      if (error !== undefined) {
+        chai.assert.fail(error, undefined, String(error));
+      }
+    });
+  }
 
-  it("Should return `true` for .testSync", function () {
+  it("Should return `true` for .test", function () {
     chai.assert.isTrue(type.test(item.value));
   });
 }
@@ -173,10 +177,10 @@ export function testSerialization<T>(type: IoType<T>, typedValue: ValidTypedValu
 
 export function testValueSync(type: Type<any>, item: TypedValue): void {
   if (item.valid) {
-    testValidValueSync(type, item);
+    testValidValue(type, item);
     testSerialization(type as IoType<any>, item);
   } else {
-    testInvalidValueSync(type, item);
+    testInvalidValue(type, item);
   }
 }
 

--- a/src/test/helpers/test.ts
+++ b/src/test/helpers/test.ts
@@ -1,10 +1,10 @@
 import bson from "bson";
 import chai from "chai";
 import qs from "qs";
+import { IoType, Type } from "../../lib/core";
 import { BsonReader } from "../../lib/readers/bson";
 import { JsonReader } from "../../lib/readers/json";
 import { QsReader } from "../../lib/readers/qs";
-import { IoType, Type } from "../../lib/types";
 import { BsonWriter } from "../../lib/writers/bson";
 import { JsonWriter } from "../../lib/writers/json";
 import { QsWriter } from "../../lib/writers/qs";

--- a/src/test/types/boolean.spec.ts
+++ b/src/test/types/boolean.spec.ts
@@ -1,3 +1,4 @@
+import chai from "chai";
 import { BooleanType } from "../../lib/types/boolean";
 import { runTests, TypedValue } from "../helpers/test";
 
@@ -30,4 +31,27 @@ describe("BooleanType", function () {
   ];
 
   runTests(type, items);
+
+  describe("lte", function () {
+    const $Boolean: BooleanType = new BooleanType();
+
+    interface TestItem {
+      left: boolean;
+      right: boolean;
+      expected: boolean;
+    }
+
+    const testItems: TestItem[] = [
+      {left: false, right: false, expected: true},
+      {left: false, right: true, expected: true},
+      {left: true, right: false, expected: false},
+      {left: true, right: true, expected: true},
+    ];
+
+    for (const {left, right, expected} of testItems) {
+      it(`.lte(${left}, ${right}) should return ${expected}`, function () {
+        chai.assert.strictEqual($Boolean.lte(left, right), expected);
+      });
+    }
+  });
 });

--- a/src/test/types/bytes.spec.ts
+++ b/src/test/types/bytes.spec.ts
@@ -1,8 +1,8 @@
-import { BufferType } from "../../lib/types/buffer";
+import { BytesType } from "../../lib/types/bytes";
 import { runTests, TypedValue } from "../helpers/test";
 
-describe("BufferType", function () {
-  const shortBuffer: BufferType = new BufferType({
+describe("BytesType", function () {
+  const shortBuffer: BytesType = new BytesType({
     maxLength: 2,
   });
 

--- a/src/test/types/custom.spec.ts
+++ b/src/test/types/custom.spec.ts
@@ -1,8 +1,8 @@
 import bson from "bson";
 import { Incident } from "incident";
+import { Reader, Writer } from "../../lib/core";
 import { createInvalidTypeError } from "../../lib/errors/invalid-type";
 import { readVisitor } from "../../lib/readers/read-visitor";
-import { Reader, Writer } from "../../lib/types";
 import { CustomType } from "../../lib/types/custom";
 import { runTests, TypedValue } from "../helpers/test";
 

--- a/src/test/types/float64.spec.ts
+++ b/src/test/types/float64.spec.ts
@@ -1,4 +1,5 @@
 import chai from "chai";
+import { BooleanType } from "../../lib/types/boolean";
 import { Float64Type } from "../../lib/types/float64";
 import { runTests, TypedValue } from "../helpers/test";
 
@@ -97,5 +98,29 @@ describe("Float64Type", function () {
     it("should return `false` for `.equals(Infinity, -Infinity)`", function () {
       chai.assert.isFalse($Float64WithInfinity.equals(Infinity, -Infinity));
     });
+  });
+
+  describe("lte", function () {
+    const $Float64: Float64Type = new Float64Type({allowNaN: true, allowInfinity: true});
+
+    interface TestItem {
+      left: number;
+      right: number;
+      expected: boolean;
+    }
+
+    const values: number[] = [-Infinity, -1, -0, +0, +1, +Infinity, NaN];
+    const testItems: TestItem[] = [];
+    for (let i: number = 0; i < values.length; i++) {
+      for (let j: number = 0; j < values.length; j++) {
+        testItems.push({left: values[i], right: values[j], expected: i <= j});
+      }
+    }
+
+    for (const {left, right, expected} of testItems) {
+      it(`.lte(${left}, ${right}) should return ${expected}`, function () {
+        chai.assert.strictEqual($Float64.lte(left, right), expected);
+      });
+    }
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -23,6 +23,16 @@
   version "0.20.0"
   resolved "https://registry.yarnpkg.com/@std/esm/-/esm-0.20.0.tgz#658cb32e3b163f20b7d9f29a78987041068b1182"
 
+"@types/babel-types@*", "@types/babel-types@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@types/babel-types/-/babel-types-7.0.0.tgz#4beb190e239fe05bac5e57e8d8376cab4f20c65c"
+
+"@types/babylon@^6.16.2":
+  version "6.16.2"
+  resolved "https://registry.yarnpkg.com/@types/babylon/-/babylon-6.16.2.tgz#062ce63b693d9af1c246f5aedf928bc9c30589c8"
+  dependencies:
+    "@types/babel-types" "*"
+
 "@types/bson@^1.0.6":
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/@types/bson/-/bson-1.0.6.tgz#8691f042d99dd163a5eb4dd6dde587d3449f7cda"
@@ -50,7 +60,7 @@
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@types/events/-/events-1.1.0.tgz#93b1be91f63c184450385272c47b6496fd028e02"
 
-"@types/fancy-log@^1.3.0":
+"@types/fancy-log@1.3.0", "@types/fancy-log@^1.3.0":
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/@types/fancy-log/-/fancy-log-1.3.0.tgz#a61ab476e5e628cd07a846330df53b85e05c8ce0"
 
@@ -132,13 +142,13 @@
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@types/minimist/-/minimist-1.2.0.tgz#69a23a3ad29caf0097f06eda59b361ee2f0639f6"
 
-"@types/mocha@^2.2.47":
+"@types/mocha@^2.2.48":
   version "2.2.48"
   resolved "https://registry.yarnpkg.com/@types/mocha/-/mocha-2.2.48.tgz#3523b126a0b049482e1c3c11877460f76622ffab"
 
-"@types/node@*", "@types/node@^9.4.0":
-  version "9.4.1"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-9.4.1.tgz#0f636f7837e15d2d73a7f6f3ea0e322eb2a5ab65"
+"@types/node@*", "@types/node@^9.4.6":
+  version "9.4.6"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-9.4.6.tgz#d8176d864ee48753d053783e4e463aec86b8d82e"
 
 "@types/object-inspect@^1.4.0":
   version "1.4.0"
@@ -173,14 +183,6 @@
   dependencies:
     "@types/glob" "*"
     "@types/node" "*"
-
-"@types/strip-bom@^3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@types/strip-bom/-/strip-bom-3.0.0.tgz#14a8ec3956c2e81edb7520790aecf21c290aebd2"
-
-"@types/strip-json-comments@0.0.30":
-  version "0.0.30"
-  resolved "https://registry.yarnpkg.com/@types/strip-json-comments/-/strip-json-comments-0.0.30.tgz#9aa30c04db212a9a0649d6ae6fd50accc40748a1"
 
 "@types/tmp@0.0.33":
   version "0.0.33"
@@ -235,7 +237,7 @@ acorn@5.X, acorn@^5.0.0, acorn@^5.0.3:
   version "5.4.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.4.1.tgz#fdc58d9d17f4a4e98d102ded826a9b9759125102"
 
-acorn@^3.1.0, acorn@~3.3.0:
+acorn@^3.1.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-3.3.0.tgz#45e37fb39e8da3f25baee3ff5369e2bb5f22017a"
 
@@ -243,9 +245,9 @@ acorn@^4.0.3, acorn@^4.0.4, acorn@~4.0.2:
   version "4.0.13"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-4.0.13.tgz#105495ae5361d697bd195c825192e1ad7f253787"
 
-ajv-keywords@^2.0.0:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-2.1.1.tgz#617997fc5f60576894c435f940d819e135b80762"
+ajv-keywords@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-3.1.0.tgz#ac2b27939c543e95d2c06e7f7f5c27be4aa543be"
 
 ajv@^4.9.1:
   version "4.11.8"
@@ -254,11 +256,19 @@ ajv@^4.9.1:
     co "^4.6.0"
     json-stable-stringify "^1.0.1"
 
-ajv@^5.1.0, ajv@^5.1.5:
+ajv@^5.1.0:
   version "5.5.2"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-5.5.2.tgz#73b5eeca3fab653e3d3f9422b341ad42205dc965"
   dependencies:
     co "^4.6.0"
+    fast-deep-equal "^1.0.0"
+    fast-json-stable-stringify "^2.0.0"
+    json-schema-traverse "^0.3.0"
+
+ajv@^6.1.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.2.0.tgz#afac295bbaa0152449e522742e4547c1ae9328d2"
+  dependencies:
     fast-deep-equal "^1.0.0"
     fast-json-stable-stringify "^2.0.0"
     json-schema-traverse "^0.3.0"
@@ -276,8 +286,8 @@ amdefine@>=0.0.4:
   resolved "https://registry.yarnpkg.com/amdefine/-/amdefine-1.0.1.tgz#4a5282ac164729e93619bcfd3ad151f817ce91f5"
 
 ansi-colors@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/ansi-colors/-/ansi-colors-1.0.1.tgz#e94c6c306005af8b482240241e2f3dea4b855ff3"
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/ansi-colors/-/ansi-colors-1.1.0.tgz#6374b4dd5d4718ff3ce27a671a3b1cad077132a9"
   dependencies:
     ansi-wrap "^0.1.0"
 
@@ -311,7 +321,7 @@ ansi-styles@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-2.2.1.tgz#b432dd3358b634cf75e1e4664368240533c1ddbe"
 
-ansi-styles@^3.1.0:
+ansi-styles@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.0.tgz#c159b8d5be0f9e5a6f346dab94f16ce022161b88"
   dependencies:
@@ -363,8 +373,8 @@ are-we-there-yet@~1.1.2:
     readable-stream "^2.0.6"
 
 argparse@^1.0.7:
-  version "1.0.9"
-  resolved "https://registry.yarnpkg.com/argparse/-/argparse-1.0.9.tgz#73d83bc263f86e97f8cc4f6bae1b0e90a7d22c86"
+  version "1.0.10"
+  resolved "https://registry.yarnpkg.com/argparse/-/argparse-1.0.10.tgz#bcd6791ea5ae09725e17e5ad988134cd40b3d911"
   dependencies:
     sprintf-js "~1.0.2"
 
@@ -481,8 +491,8 @@ asap@~2.0.3:
   resolved "https://registry.yarnpkg.com/asap/-/asap-2.0.6.tgz#e50347611d7e690943208bbdafebcbc2fb866d46"
 
 asn1.js@^4.0.0:
-  version "4.9.2"
-  resolved "https://registry.yarnpkg.com/asn1.js/-/asn1.js-4.9.2.tgz#8117ef4f7ed87cd8f89044b5bff97ac243a16c9a"
+  version "4.10.1"
+  resolved "https://registry.yarnpkg.com/asn1.js/-/asn1.js-4.10.1.tgz#b9c2bf5805f1e64aadeed6df3a2bfafb5a73f5a0"
   dependencies:
     bn.js "^4.0.0"
     inherits "^2.0.1"
@@ -661,8 +671,8 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
 
 base64-js@^1.0.2:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.2.1.tgz#a91947da1f4a516ea38e5b4ec0ec3773675e0886"
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.2.3.tgz#fb13668233d9614cf5fb4bce95a9ba4096cdf801"
 
 base@^0.11.1:
   version "0.11.2"
@@ -729,8 +739,8 @@ boom@5.x.x:
     hoek "4.x.x"
 
 brace-expansion@^1.1.7:
-  version "1.1.8"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.8.tgz#c07b211c7c952ec1f8efd51a77ef0d1d3990a292"
+  version "1.1.11"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
   dependencies:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
@@ -743,9 +753,9 @@ braces@^1.8.2:
     preserve "^0.2.0"
     repeat-element "^1.1.2"
 
-braces@^2.3.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/braces/-/braces-2.3.0.tgz#a46941cb5fb492156b3d6a656e06c35364e3e66e"
+braces@^2.3.0, braces@^2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/braces/-/braces-2.3.1.tgz#7086c913b4e5a08dbe37ac0ee6a2500c4ba691bb"
   dependencies:
     arr-flatten "^1.1.0"
     array-unique "^0.3.2"
@@ -753,6 +763,7 @@ braces@^2.3.0:
     extend-shallow "^2.0.1"
     fill-range "^4.0.0"
     isobject "^3.0.1"
+    kind-of "^6.0.2"
     repeat-element "^1.1.2"
     snapdragon "^0.8.1"
     snapdragon-node "^2.0.1"
@@ -918,6 +929,14 @@ chai@^4.1.2:
     pathval "^1.0.0"
     type-detect "^4.0.0"
 
+chalk@2.3.1, chalk@^2.3.0:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.3.1.tgz#523fe2678aec7b04e8041909292fe8b17059b796"
+  dependencies:
+    ansi-styles "^3.2.0"
+    escape-string-regexp "^1.0.5"
+    supports-color "^5.2.0"
+
 chalk@^1.0.0, chalk@^1.1.1, chalk@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-1.1.3.tgz#a8115c55e4a702fe4d150abd3872822a7e09fc98"
@@ -927,14 +946,6 @@ chalk@^1.0.0, chalk@^1.1.1, chalk@^1.1.3:
     has-ansi "^2.0.0"
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
-
-chalk@^2.3.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.3.0.tgz#b5ea48efc9c1793dccc9b4767c93914d3f2d52ba"
-  dependencies:
-    ansi-styles "^3.1.0"
-    escape-string-regexp "^1.0.5"
-    supports-color "^4.0.0"
 
 character-parser@^2.1.1:
   version "2.2.0"
@@ -962,8 +973,8 @@ chokidar@^1.7.0:
     fsevents "^1.0.0"
 
 chokidar@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-2.0.0.tgz#6686313c541d3274b2a5c01233342037948c911b"
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-2.0.2.tgz#4dc65139eeb2714977735b6a35d06e97b494dfd7"
   dependencies:
     anymatch "^2.0.0"
     async-each "^1.0.0"
@@ -975,6 +986,7 @@ chokidar@^2.0.0:
     normalize-path "^2.1.1"
     path-is-absolute "^1.0.0"
     readdirp "^2.0.0"
+    upath "^1.0.0"
   optionalDependencies:
     fsevents "^1.0.0"
 
@@ -1098,9 +1110,9 @@ color-support@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/color-support/-/color-support-1.1.3.tgz#93834379a1cc9a0c61f82f52f0d04322251bd5a2"
 
-combined-stream@^1.0.5, combined-stream@~1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.5.tgz#938370a57b4a51dea2c77c15d5c5fdf895164009"
+combined-stream@1.0.6, combined-stream@^1.0.5, combined-stream@~1.0.5:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.6.tgz#723e7df6e801ac5613113a7e445a9b69cb632818"
   dependencies:
     delayed-stream "~1.0.0"
 
@@ -1149,17 +1161,19 @@ console-control-strings@^1.0.0, console-control-strings@~1.1.0:
   resolved "https://registry.yarnpkg.com/console-control-strings/-/console-control-strings-1.1.0.tgz#3d7cf4464db6446ea644bf4b39507f9851008e8e"
 
 constantinople@^3.0.1:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/constantinople/-/constantinople-3.1.0.tgz#7569caa8aa3f8d5935d62e1fa96f9f702cd81c79"
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/constantinople/-/constantinople-3.1.2.tgz#d45ed724f57d3d10500017a7d3a889c1381ae647"
   dependencies:
-    acorn "^3.1.0"
-    is-expression "^2.0.1"
+    "@types/babel-types" "^7.0.0"
+    "@types/babylon" "^6.16.2"
+    babel-types "^6.26.0"
+    babylon "^6.18.0"
 
 constants-browserify@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/constants-browserify/-/constants-browserify-1.0.0.tgz#c20b96d8c617748aaf1c16021760cd27fcb8cb75"
 
-convert-source-map@1.X, convert-source-map@^1.1.1, convert-source-map@^1.3.0, convert-source-map@^1.5.0:
+convert-source-map@1.X, convert-source-map@^1.1.1, convert-source-map@^1.5.0, convert-source-map@^1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.5.1.tgz#b8278097b9bc229365de5c62cf5fcaed8b5599e5"
 
@@ -1375,6 +1389,13 @@ define-property@^1.0.0:
   dependencies:
     is-descriptor "^1.0.0"
 
+define-property@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/define-property/-/define-property-2.0.2.tgz#d459689e8d654ba77e02a817f8710d702cb16e9d"
+  dependencies:
+    is-descriptor "^1.0.2"
+    isobject "^3.0.1"
+
 del@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/del/-/del-3.0.0.tgz#53ecf699ffcbcb39637691ab13baf160819766e5"
@@ -1513,8 +1534,8 @@ enhanced-resolve@^3.4.0:
     tapable "^0.2.7"
 
 errno@^0.1.3:
-  version "0.1.6"
-  resolved "https://registry.yarnpkg.com/errno/-/errno-0.1.6.tgz#c386ce8a6283f14fc09563b71560908c9bf53026"
+  version "0.1.7"
+  resolved "https://registry.yarnpkg.com/errno/-/errno-0.1.7.tgz#4684d71779ad39af177e3f007996f7c67c852618"
   dependencies:
     prr "~1.0.1"
 
@@ -1525,8 +1546,8 @@ error-ex@^1.2.0:
     is-arrayish "^0.2.1"
 
 es5-ext@^0.10.14, es5-ext@^0.10.30, es5-ext@^0.10.35, es5-ext@^0.10.9, es5-ext@~0.10.14, es5-ext@~0.10.2:
-  version "0.10.38"
-  resolved "https://registry.yarnpkg.com/es5-ext/-/es5-ext-0.10.38.tgz#fa7d40d65bbc9bb8a67e1d3f9cc656a00530eed3"
+  version "0.10.39"
+  resolved "https://registry.yarnpkg.com/es5-ext/-/es5-ext-0.10.39.tgz#fca21b67559277ca4ac1a1ed7048b107b6f76d87"
   dependencies:
     es6-iterator "~2.0.3"
     es6-symbol "~3.1.1"
@@ -1594,11 +1615,10 @@ esprima@^4.0.0:
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.0.tgz#4499eddcd1110e0b218bacf2fa7f7f59f55ca804"
 
 esrecurse@^4.1.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/esrecurse/-/esrecurse-4.2.0.tgz#fa9568d98d3823f9a41d91e902dcab9ea6e5b163"
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/esrecurse/-/esrecurse-4.2.1.tgz#007a3b9fdbc2b3bb87e4879ea19c92fdbd3942cf"
   dependencies:
     estraverse "^4.1.0"
-    object-assign "^4.0.1"
 
 estraverse@^4.1.0, estraverse@^4.1.1:
   version "4.2.0"
@@ -1721,7 +1741,7 @@ extglob@^0.3.1:
   dependencies:
     is-extglob "^1.0.0"
 
-extglob@^2.0.2:
+extglob@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/extglob/-/extglob-2.0.4.tgz#ad00fe4dc612a9232e8718711dc5cb5ab0285543"
   dependencies:
@@ -1742,7 +1762,7 @@ extsprintf@^1.2.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.4.0.tgz#e2689f8f356fad62cca65a3a91c5df5f9551692f"
 
-fancy-log@^1.1.0, fancy-log@^1.3.2:
+fancy-log@1.3.2, fancy-log@^1.1.0, fancy-log@^1.3.2:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/fancy-log/-/fancy-log-1.3.2.tgz#f41125e3d84f2e7d89a43d06d958c8f78be16be1"
   dependencies:
@@ -1751,8 +1771,8 @@ fancy-log@^1.1.0, fancy-log@^1.3.2:
     time-stamp "^1.0.0"
 
 fast-deep-equal@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz#96256a3bc975595eb36d82e9929d060d893439ff"
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz#c053477817c86b51daa853c81e059b733d023614"
 
 fast-json-stable-stringify@^2.0.0:
   version "2.0.0"
@@ -1876,11 +1896,11 @@ form-data@~2.1.1:
     mime-types "^2.1.12"
 
 form-data@~2.3.1:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.3.1.tgz#6fb94fbd71885306d73d15cc497fe4cc4ecd44bf"
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.3.2.tgz#4970498be604c20c005d4f5c23aecd21d6b49099"
   dependencies:
     asynckit "^0.4.0"
-    combined-stream "^1.0.5"
+    combined-stream "1.0.6"
     mime-types "^2.1.12"
 
 fragment-cache@^0.2.1:
@@ -2044,8 +2064,8 @@ glob-stream@^6.1.0:
     unique-stream "^2.0.2"
 
 glob-watcher@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/glob-watcher/-/glob-watcher-5.0.0.tgz#5e147887f8733134c212bc19697dda19a029eb2e"
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/glob-watcher/-/glob-watcher-5.0.1.tgz#239aaa621b6bd843b288fdf6b155f50963c7d7ea"
   dependencies:
     async-done "^1.2.0"
     chokidar "^2.0.0"
@@ -2225,11 +2245,14 @@ gulp-sourcemaps@^2.6.1:
     through2 "2.X"
 
 gulp-tslint@^8.1.2:
-  version "8.1.2"
-  resolved "https://registry.yarnpkg.com/gulp-tslint/-/gulp-tslint-8.1.2.tgz#e0f43194b473d7e76bb45a58fe8c60e7dfe3beb2"
+  version "8.1.3"
+  resolved "https://registry.yarnpkg.com/gulp-tslint/-/gulp-tslint-8.1.3.tgz#a89ed144038ae861ee7bfea9528272d126a93da1"
   dependencies:
-    gulp-util "~3.0.8"
+    "@types/fancy-log" "1.3.0"
+    chalk "2.3.1"
+    fancy-log "1.3.2"
     map-stream "~0.0.7"
+    plugin-error "1.0.1"
     through "~2.3.8"
 
 gulp-typedoc@^2.2.0:
@@ -2250,7 +2273,7 @@ gulp-typescript@^3.2.3:
     through2 "~2.0.1"
     vinyl-fs "~2.4.3"
 
-gulp-util@^3.0, gulp-util@^3.0.2, gulp-util@^3.0.7, gulp-util@~3.0.7, gulp-util@~3.0.8:
+gulp-util@^3.0, gulp-util@^3.0.2, gulp-util@~3.0.7:
   version "3.0.8"
   resolved "https://registry.yarnpkg.com/gulp-util/-/gulp-util-3.0.8.tgz#0054e1e744502e27c04c187c3ecc505dd54bbb4f"
   dependencies:
@@ -2342,6 +2365,10 @@ has-flag@^1.0.0:
 has-flag@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-2.0.0.tgz#e8207af1cc7b30d446cc70b734b5e8be18f88d51"
+
+has-flag@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
 
 has-gulplog@^0.1.0:
   version "0.1.0"
@@ -2449,8 +2476,8 @@ hoek@2.x.x:
   resolved "https://registry.yarnpkg.com/hoek/-/hoek-2.16.3.tgz#20bb7403d3cea398e91dc4710a8ff1b8274a25ed"
 
 hoek@4.x.x:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/hoek/-/hoek-4.2.0.tgz#72d9d0754f7fe25ca2d01ad8f8f9a9449a89526d"
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/hoek/-/hoek-4.2.1.tgz#9634502aa12c445dd5a7c5734b572bb8738aacbb"
 
 homedir-polyfill@^1.0.1:
   version "1.0.1"
@@ -2535,8 +2562,8 @@ interpret@^1.0.0, interpret@^1.1.0:
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.1.0.tgz#7ed1b1410c6a0e0f78cf95d3b8440c63f78b8614"
 
 invariant@^2.2.2:
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.2.tgz#9e1f56ac0acdb6bf303306f338be3b204ae60360"
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.3.tgz#1a827dfde7dcbd7c323f0ca826be8fa7c5e9d688"
   dependencies:
     loose-envify "^1.0.0"
 
@@ -2603,7 +2630,7 @@ is-descriptor@^0.1.0:
     is-data-descriptor "^0.1.4"
     kind-of "^5.0.0"
 
-is-descriptor@^1.0.0:
+is-descriptor@^1.0.0, is-descriptor@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-descriptor/-/is-descriptor-1.0.2.tgz#3b159746a66604b04f8c81524ba365c5f14d86ec"
   dependencies:
@@ -2620,13 +2647,6 @@ is-equal-shallow@^0.1.3:
   resolved "https://registry.yarnpkg.com/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz#2238098fc221de0bcfa5d9eac4c45d638aa1c534"
   dependencies:
     is-primitive "^2.0.0"
-
-is-expression@^2.0.1:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/is-expression/-/is-expression-2.1.0.tgz#91be9d47debcfef077977e9722be6dcfb4465ef0"
-  dependencies:
-    acorn "~3.3.0"
-    object-assign "^4.0.1"
 
 is-expression@^3.0.0:
   version "3.0.0"
@@ -2687,12 +2707,17 @@ is-glob@^4.0.0:
   dependencies:
     is-extglob "^2.1.1"
 
+is-my-ip-valid@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-my-ip-valid/-/is-my-ip-valid-1.0.0.tgz#7b351b8e8edd4d3995d4d066680e664d94696824"
+
 is-my-json-valid@^2.12.4:
-  version "2.17.1"
-  resolved "https://registry.yarnpkg.com/is-my-json-valid/-/is-my-json-valid-2.17.1.tgz#3da98914a70a22f0a8563ef1511a246c6fc55471"
+  version "2.17.2"
+  resolved "https://registry.yarnpkg.com/is-my-json-valid/-/is-my-json-valid-2.17.2.tgz#6b2103a288e94ef3de5cf15d29dd85fc4b78d65c"
   dependencies:
     generate-function "^2.0.0"
     generate-object-property "^1.1.0"
+    is-my-ip-valid "^1.0.0"
     jsonpointer "^4.0.0"
     xtend "^4.0.0"
 
@@ -2716,11 +2741,11 @@ is-number@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-4.0.0.tgz#0026e37f5454d73e356dfe6564699867c6a7f0ff"
 
-is-odd@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/is-odd/-/is-odd-1.0.0.tgz#3b8a932eb028b3775c39bb09e91767accdb69088"
+is-odd@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/is-odd/-/is-odd-2.0.0.tgz#7646624671fd7ea558ccd9a2795182f2958f1b24"
   dependencies:
-    is-number "^3.0.0"
+    is-number "^4.0.0"
 
 is-path-cwd@^1.0.0:
   version "1.0.0"
@@ -2798,9 +2823,9 @@ is-valid-glob@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-valid-glob/-/is-valid-glob-1.0.0.tgz#29bf3eff701be2d4d315dbacc39bc39fe8f601aa"
 
-is-windows@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.1.tgz#310db70f742d259a16a369202b51af84233310d9"
+is-windows@^1.0.1, is-windows@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.2.tgz#d1850eb9791ecd18e6182ce12a30f396634bb19d"
 
 isarray@0.0.1:
   version "0.0.1"
@@ -2828,9 +2853,9 @@ isstream@~0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
 
-istanbul-lib-coverage@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/istanbul-lib-coverage/-/istanbul-lib-coverage-1.1.1.tgz#73bfb998885299415c93d38a3e9adf784a77a9da"
+istanbul-lib-coverage@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-coverage/-/istanbul-lib-coverage-1.1.2.tgz#4113c8ff6b7a40a1ef7350b01016331f63afde14"
 
 istanbul-lib-hook@^1.1.0:
   version "1.1.0"
@@ -2838,40 +2863,40 @@ istanbul-lib-hook@^1.1.0:
   dependencies:
     append-transform "^0.4.0"
 
-istanbul-lib-instrument@^1.9.1:
-  version "1.9.1"
-  resolved "https://registry.yarnpkg.com/istanbul-lib-instrument/-/istanbul-lib-instrument-1.9.1.tgz#250b30b3531e5d3251299fdd64b0b2c9db6b558e"
+istanbul-lib-instrument@^1.9.2:
+  version "1.9.2"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-instrument/-/istanbul-lib-instrument-1.9.2.tgz#84905bf47f7e0b401d6b840da7bad67086b4aab6"
   dependencies:
     babel-generator "^6.18.0"
     babel-template "^6.16.0"
     babel-traverse "^6.18.0"
     babel-types "^6.18.0"
     babylon "^6.18.0"
-    istanbul-lib-coverage "^1.1.1"
+    istanbul-lib-coverage "^1.1.2"
     semver "^5.3.0"
 
-istanbul-lib-report@^1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/istanbul-lib-report/-/istanbul-lib-report-1.1.2.tgz#922be27c13b9511b979bd1587359f69798c1d425"
+istanbul-lib-report@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-report/-/istanbul-lib-report-1.1.3.tgz#2df12188c0fa77990c0d2176d2d0ba3394188259"
   dependencies:
-    istanbul-lib-coverage "^1.1.1"
+    istanbul-lib-coverage "^1.1.2"
     mkdirp "^0.5.1"
     path-parse "^1.0.5"
     supports-color "^3.1.2"
 
-istanbul-lib-source-maps@^1.2.2:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.2.tgz#750578602435f28a0c04ee6d7d9e0f2960e62c1c"
+istanbul-lib-source-maps@^1.2.3:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.3.tgz#20fb54b14e14b3fb6edb6aca3571fd2143db44e6"
   dependencies:
     debug "^3.1.0"
-    istanbul-lib-coverage "^1.1.1"
+    istanbul-lib-coverage "^1.1.2"
     mkdirp "^0.5.1"
     rimraf "^2.6.1"
     source-map "^0.5.3"
 
-istanbul-reports@^1.1.3:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/istanbul-reports/-/istanbul-reports-1.1.3.tgz#3b9e1e8defb6d18b1d425da8e8b32c5a163f2d10"
+istanbul-reports@^1.1.4:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/istanbul-reports/-/istanbul-reports-1.1.4.tgz#5ccba5e22b7b5a5d91d5e0a830f89be334bf97bd"
   dependencies:
     handlebars "^4.0.3"
 
@@ -3179,7 +3204,7 @@ lodash.templatesettings@^3.0.0:
     lodash._reinterpolate "^3.0.0"
     lodash.escape "^3.0.0"
 
-lodash@^4.0.0, lodash@^4.13.1, lodash@^4.14.0, lodash@^4.17.4, lodash@~4.17.4:
+lodash@^4.0.0, lodash@^4.13.1, lodash@^4.14.0, lodash@^4.17.4, lodash@^4.17.5, lodash@~4.17.4:
   version "4.17.5"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.5.tgz#99a92d65c0272debe8c96b6057bc8fbfa3bed511"
 
@@ -3214,8 +3239,8 @@ lru-queue@0.1:
     es5-ext "~0.10.2"
 
 make-error@^1.1.1:
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.3.tgz#a97ae14ffd98b05f543e83ddc395e1b2b6e4cc6a"
+  version "1.3.4"
+  resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.4.tgz#19978ed575f9e9545d2ff8c13e33b5d18a67d535"
 
 make-iterator@^1.0.0:
   version "1.0.0"
@@ -3246,8 +3271,8 @@ map-visit@^1.0.0:
     object-visit "^1.0.0"
 
 marked@^0.3.12:
-  version "0.3.12"
-  resolved "https://registry.yarnpkg.com/marked/-/marked-0.3.12.tgz#7cf25ff2252632f3fe2406bde258e94eee927519"
+  version "0.3.16"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-0.3.16.tgz#2f188b7dfcfa6540fe9940adaf0f3b791c9a5cba"
 
 matchdep@^2.0.0:
   version "2.0.0"
@@ -3282,8 +3307,8 @@ mem@^1.1.0:
     mimic-fn "^1.0.0"
 
 memoizee@0.4.X:
-  version "0.4.11"
-  resolved "https://registry.yarnpkg.com/memoizee/-/memoizee-0.4.11.tgz#bde9817663c9e40fdb2a4ea1c367296087ae8c8f"
+  version "0.4.12"
+  resolved "https://registry.yarnpkg.com/memoizee/-/memoizee-0.4.12.tgz#780e99a219c50c549be6d0fc61765080975c58fb"
   dependencies:
     d "1"
     es5-ext "^0.10.30"
@@ -3351,18 +3376,18 @@ micromatch@^2.1.5, micromatch@^2.3.11, micromatch@^2.3.7:
     regex-cache "^0.4.2"
 
 micromatch@^3.0.4, micromatch@^3.1.4:
-  version "3.1.5"
-  resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-3.1.5.tgz#d05e168c206472dfbca985bfef4f57797b4cd4ba"
+  version "3.1.9"
+  resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-3.1.9.tgz#15dc93175ae39e52e93087847096effc73efcf89"
   dependencies:
     arr-diff "^4.0.0"
     array-unique "^0.3.2"
-    braces "^2.3.0"
-    define-property "^1.0.0"
-    extend-shallow "^2.0.1"
-    extglob "^2.0.2"
+    braces "^2.3.1"
+    define-property "^2.0.2"
+    extend-shallow "^3.0.2"
+    extglob "^2.0.4"
     fragment-cache "^0.2.1"
-    kind-of "^6.0.0"
-    nanomatch "^1.2.5"
+    kind-of "^6.0.2"
+    nanomatch "^1.2.9"
     object.pick "^1.3.0"
     regex-not "^1.0.0"
     snapdragon "^0.8.1"
@@ -3375,15 +3400,15 @@ miller-rabin@^4.0.0:
     bn.js "^4.0.0"
     brorand "^1.0.1"
 
-mime-db@~1.30.0:
-  version "1.30.0"
-  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.30.0.tgz#74c643da2dd9d6a45399963465b26d5ca7d71f01"
+mime-db@~1.33.0:
+  version "1.33.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.33.0.tgz#a3492050a5cb9b63450541e39d9788d2272783db"
 
 mime-types@^2.1.12, mime-types@~2.1.17, mime-types@~2.1.7:
-  version "2.1.17"
-  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.17.tgz#09d7a393f03e995a79f8af857b70a9e0ab16557a"
+  version "2.1.18"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.18.tgz#6f323f60a83d11146f831ff11fd66e2fe5503bb8"
   dependencies:
-    mime-db "~1.30.0"
+    mime-db "~1.33.0"
 
 mimic-fn@^1.0.0:
   version "1.2.0"
@@ -3444,8 +3469,8 @@ mocha@^4.1.0:
     supports-color "4.4.0"
 
 mocha@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/mocha/-/mocha-5.0.0.tgz#cccac988b0bc5477119cba0e43de7af6d6ad8f4e"
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/mocha/-/mocha-5.0.1.tgz#759b62c836b0732382a62b6b1fb245ec1bc943ac"
   dependencies:
     browser-stdout "1.3.0"
     commander "2.11.0"
@@ -3473,20 +3498,21 @@ mute-stdout@^1.0.0:
   resolved "https://registry.yarnpkg.com/mute-stdout/-/mute-stdout-1.0.0.tgz#5b32ea07eb43c9ded6130434cf926f46b2a7fd4d"
 
 nan@^2.3.0, nan@^2.3.2:
-  version "2.8.0"
-  resolved "https://registry.yarnpkg.com/nan/-/nan-2.8.0.tgz#ed715f3fe9de02b57a5e6252d90a96675e1f085a"
+  version "2.9.2"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.9.2.tgz#f564d75f5f8f36a6d9456cca7a6c4fe488ab7866"
 
-nanomatch@^1.2.5:
-  version "1.2.7"
-  resolved "https://registry.yarnpkg.com/nanomatch/-/nanomatch-1.2.7.tgz#53cd4aa109ff68b7f869591fdc9d10daeeea3e79"
+nanomatch@^1.2.9:
+  version "1.2.9"
+  resolved "https://registry.yarnpkg.com/nanomatch/-/nanomatch-1.2.9.tgz#879f7150cb2dab7a471259066c104eee6e0fa7c2"
   dependencies:
     arr-diff "^4.0.0"
     array-unique "^0.3.2"
-    define-property "^1.0.0"
-    extend-shallow "^2.0.1"
+    define-property "^2.0.2"
+    extend-shallow "^3.0.2"
     fragment-cache "^0.2.1"
-    is-odd "^1.0.0"
-    kind-of "^5.0.2"
+    is-odd "^2.0.0"
+    is-windows "^1.0.2"
+    kind-of "^6.0.2"
     object.pick "^1.3.0"
     regex-not "^1.0.0"
     snapdragon "^0.8.1"
@@ -3636,25 +3662,25 @@ number-is-nan@^1.0.0:
   resolved "https://registry.yarnpkg.com/number-is-nan/-/number-is-nan-1.0.1.tgz#097b602b53422a522c1afb8790318336941a011d"
 
 nyc@^11.3.0:
-  version "11.4.1"
-  resolved "https://registry.yarnpkg.com/nyc/-/nyc-11.4.1.tgz#13fdf7e7ef22d027c61d174758f6978a68f4f5e5"
+  version "11.5.0"
+  resolved "https://registry.yarnpkg.com/nyc/-/nyc-11.5.0.tgz#29795d8217885e8b384d849fbe74956d58be2252"
   dependencies:
     archy "^1.0.0"
     arrify "^1.0.1"
     caching-transform "^1.0.0"
-    convert-source-map "^1.3.0"
+    convert-source-map "^1.5.1"
     debug-log "^1.0.1"
     default-require-extensions "^1.0.0"
     find-cache-dir "^0.1.1"
     find-up "^2.1.0"
     foreground-child "^1.5.3"
     glob "^7.0.6"
-    istanbul-lib-coverage "^1.1.1"
+    istanbul-lib-coverage "^1.1.2"
     istanbul-lib-hook "^1.1.0"
-    istanbul-lib-instrument "^1.9.1"
-    istanbul-lib-report "^1.1.2"
-    istanbul-lib-source-maps "^1.2.2"
-    istanbul-reports "^1.1.3"
+    istanbul-lib-instrument "^1.9.2"
+    istanbul-lib-report "^1.1.3"
+    istanbul-lib-source-maps "^1.2.3"
+    istanbul-reports "^1.1.4"
     md5-hex "^1.2.0"
     merge-source-map "^1.0.2"
     micromatch "^2.3.11"
@@ -3663,7 +3689,7 @@ nyc@^11.3.0:
     rimraf "^2.5.4"
     signal-exit "^3.0.1"
     spawn-wrap "^1.4.2"
-    test-exclude "^4.1.1"
+    test-exclude "^4.2.0"
     yargs "^10.0.3"
     yargs-parser "^8.0.0"
 
@@ -3817,8 +3843,8 @@ os-tmpdir@^1.0.0, os-tmpdir@~1.0.2:
   resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
 
 osenv@0, osenv@^0.1.4:
-  version "0.1.4"
-  resolved "https://registry.yarnpkg.com/osenv/-/osenv-0.1.4.tgz#42fe6d5953df06c8064be6f176c3d05aaaa34644"
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/osenv/-/osenv-0.1.5.tgz#85cdfafaeb28e8677f416e287592b5f3f49ea410"
   dependencies:
     os-homedir "^1.0.0"
     os-tmpdir "^1.0.0"
@@ -4002,6 +4028,15 @@ pkg-dir@^1.0.0:
   dependencies:
     find-up "^1.0.0"
 
+plugin-error@1.0.1, plugin-error@^1.0.0, plugin-error@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/plugin-error/-/plugin-error-1.0.1.tgz#77016bd8919d0ac377fdcdd0322328953ca5781c"
+  dependencies:
+    ansi-colors "^1.0.1"
+    arr-diff "^4.0.0"
+    arr-union "^3.1.0"
+    extend-shallow "^3.0.2"
+
 plugin-error@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/plugin-error/-/plugin-error-0.1.2.tgz#3b9bb3335ccf00f425e07437e19276967da47ace"
@@ -4011,15 +4046,6 @@ plugin-error@^0.1.2:
     arr-diff "^1.0.1"
     arr-union "^2.0.1"
     extend-shallow "^1.1.2"
-
-plugin-error@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/plugin-error/-/plugin-error-1.0.1.tgz#77016bd8919d0ac377fdcdd0322328953ca5781c"
-  dependencies:
-    ansi-colors "^1.0.1"
-    arr-diff "^4.0.0"
-    arr-union "^3.1.0"
-    extend-shallow "^3.0.2"
 
 posix-character-classes@^0.1.0:
   version "0.1.1"
@@ -4041,9 +4067,13 @@ pretty-hrtime@^1.0.0:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz#b7e3ea42435a4c9b2759d99e0f201eb195802ee1"
 
-process-nextick-args@^1.0.6, process-nextick-args@^1.0.7, process-nextick-args@~1.0.6:
+process-nextick-args@^1.0.6, process-nextick-args@^1.0.7:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-1.0.7.tgz#150e20b756590ad3f91093f25a4f2ad8bff30ba3"
+
+process-nextick-args@~2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.0.tgz#a37d732f4271b4ab1ad070d35508e8290788ffaa"
 
 process@^0.11.10:
   version "0.11.10"
@@ -4227,8 +4257,8 @@ randombytes@^2.0.0, randombytes@^2.0.1, randombytes@^2.0.5:
     safe-buffer "^5.1.0"
 
 randomfill@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/randomfill/-/randomfill-1.0.3.tgz#b96b7df587f01dd91726c418f30553b1418e3d62"
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/randomfill/-/randomfill-1.0.4.tgz#c92196fc86ab42be983f1bf31778224931d61458"
   dependencies:
     randombytes "^2.0.5"
     safe-buffer "^5.1.0"
@@ -4286,13 +4316,13 @@ read-pkg@^2.0.0:
     string_decoder "~0.10.x"
 
 readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.4, readable-stream@^2.0.5, readable-stream@^2.0.6, readable-stream@^2.1.4, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@^2.3.3:
-  version "2.3.3"
-  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.3.tgz#368f2512d79f9d46fdfc71349ae7878bbc1eb95c"
+  version "2.3.4"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.4.tgz#c946c3f47fa7d8eabc0b6150f4a12f69a4574071"
   dependencies:
     core-util-is "~1.0.0"
     inherits "~2.0.3"
     isarray "~1.0.0"
-    process-nextick-args "~1.0.6"
+    process-nextick-args "~2.0.0"
     safe-buffer "~5.1.1"
     string_decoder "~1.0.3"
     util-deprecate "~1.0.1"
@@ -4338,11 +4368,12 @@ regex-cache@^0.4.2:
   dependencies:
     is-equal-shallow "^0.1.3"
 
-regex-not@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/regex-not/-/regex-not-1.0.0.tgz#42f83e39771622df826b02af176525d6a5f157f9"
+regex-not@^1.0.0, regex-not@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/regex-not/-/regex-not-1.0.2.tgz#1f4ece27e00b0b65e0247a6810e6a85d83a5752c"
   dependencies:
-    extend-shallow "^2.0.1"
+    extend-shallow "^3.0.2"
+    safe-regex "^1.1.0"
 
 remove-bom-buffer@^3.0.0:
   version "3.0.0"
@@ -4507,6 +4538,10 @@ resolve@^1.1.6, resolve@^1.1.7, resolve@^1.3.2, resolve@^1.4.0:
   dependencies:
     path-parse "^1.0.5"
 
+ret@~0.1.10:
+  version "0.1.15"
+  resolved "https://registry.yarnpkg.com/ret/-/ret-0.1.15.tgz#b8a4825d5bdb1fc3f6f53c2bc33f81388681c7bc"
+
 right-align@^0.1.1:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/right-align/-/right-align-0.1.3.tgz#61339b722fe6a3515689210d24e14c96148613ef"
@@ -4529,6 +4564,12 @@ ripemd160@^2.0.0, ripemd160@^2.0.1:
 safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.1, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.1.tgz#893312af69b2123def71f57889001671eeb2c853"
+
+safe-regex@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/safe-regex/-/safe-regex-1.1.0.tgz#40a3669f3b077d1e943d44629e157dd48023bf2e"
+  dependencies:
+    ret "~0.1.10"
 
 sass-graph@^2.2.4:
   version "2.2.4"
@@ -4695,7 +4736,7 @@ source-map-resolve@^0.5.0:
     source-map-url "^0.4.0"
     urix "^0.1.0"
 
-source-map-support@^0.5.0:
+source-map-support@^0.5.3:
   version "0.5.3"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.3.tgz#2b3d5fff298cfa4d1afd7d4352d569e9a0158e76"
   dependencies:
@@ -4826,8 +4867,8 @@ stream-combiner@~0.0.4:
     duplexer "~0.1.1"
 
 stream-consume@~0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/stream-consume/-/stream-consume-0.1.0.tgz#a41ead1a6d6081ceb79f65b061901b6d8f3d1d0f"
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/stream-consume/-/stream-consume-0.1.1.tgz#d3bdb598c2bd0ae82b8cac7ac50b1107a7996c48"
 
 stream-exhaust@^1.0.1:
   version "1.0.2"
@@ -4919,7 +4960,7 @@ strip-indent@^1.0.1:
   dependencies:
     get-stdin "^4.0.1"
 
-strip-json-comments@^2.0.0, strip-json-comments@~2.0.1:
+strip-json-comments@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
 
@@ -4939,11 +4980,17 @@ supports-color@^3.1.2:
   dependencies:
     has-flag "^1.0.0"
 
-supports-color@^4.0.0, supports-color@^4.2.1:
+supports-color@^4.2.1:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-4.5.0.tgz#be7a0de484dec5c5cddf8b3d59125044912f635b"
   dependencies:
     has-flag "^2.0.0"
+
+supports-color@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.2.0.tgz#b0d5333b1184dd3666cbe5aa0b45c5ac7ac17a4a"
+  dependencies:
+    has-flag "^3.0.0"
 
 sver-compat@^1.5.0:
   version "1.5.0"
@@ -4977,9 +5024,9 @@ tar@^2.0.0, tar@^2.2.1:
     fstream "^1.0.2"
     inherits "2"
 
-test-exclude@^4.1.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/test-exclude/-/test-exclude-4.1.1.tgz#4d84964b0966b0087ecc334a2ce002d3d9341e26"
+test-exclude@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/test-exclude/-/test-exclude-4.2.0.tgz#07e3613609a362c74516a717515e13322ab45b3c"
   dependencies:
     arrify "^1.0.1"
     micromatch "^2.3.11"
@@ -5070,12 +5117,13 @@ to-regex-range@^2.1.0:
     repeat-string "^1.6.1"
 
 to-regex@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/to-regex/-/to-regex-3.0.1.tgz#15358bee4a2c83bd76377ba1dc049d0f18837aae"
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/to-regex/-/to-regex-3.0.2.tgz#13cfdd9b336552f30b51f33a8ae1b42a7a7599ce"
   dependencies:
-    define-property "^0.2.5"
-    extend-shallow "^2.0.1"
-    regex-not "^1.0.0"
+    define-property "^2.0.2"
+    extend-shallow "^3.0.2"
+    regex-not "^1.0.2"
+    safe-regex "^1.1.0"
 
 to-through@^2.0.0:
   version "2.0.0"
@@ -5107,9 +5155,9 @@ trim-right@^1.0.1:
   dependencies:
     glob "^6.0.4"
 
-ts-node@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-4.1.0.tgz#36d9529c7b90bb993306c408cd07f7743de20712"
+ts-node@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-5.0.0.tgz#9aa573889ad7949411f972981c209e064705e36f"
   dependencies:
     arrify "^1.0.0"
     chalk "^2.3.0"
@@ -5117,19 +5165,8 @@ ts-node@^4.1.0:
     make-error "^1.1.1"
     minimist "^1.2.0"
     mkdirp "^0.5.1"
-    source-map-support "^0.5.0"
-    tsconfig "^7.0.0"
-    v8flags "^3.0.0"
+    source-map-support "^0.5.3"
     yn "^2.0.0"
-
-tsconfig@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/tsconfig/-/tsconfig-7.0.0.tgz#84538875a4dc216e5c4a5432b3a4dec3d54e91b7"
-  dependencies:
-    "@types/strip-bom" "^3.0.0"
-    "@types/strip-json-comments" "0.0.30"
-    strip-bom "^3.0.0"
-    strip-json-comments "^2.0.0"
 
 tslib@^1.8.0, tslib@^1.8.1:
   version "1.9.0"
@@ -5153,8 +5190,8 @@ tslint@^5.8.0:
     tsutils "^2.12.1"
 
 tsutils@^2.12.1:
-  version "2.21.0"
-  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-2.21.0.tgz#43466a2283a0abce64e2209bc732ad72f8a04fab"
+  version "2.21.2"
+  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-2.21.2.tgz#902aa5987e1440c47673543d96752df8d44ab9c7"
   dependencies:
     tslib "^1.8.1"
 
@@ -5266,9 +5303,13 @@ typedoc@^0.10.0:
     typedoc-default-themes "^0.5.0"
     typescript "2.7.1"
 
-typescript@2.7.1, typescript@^2.7.1:
+typescript@2.7.1:
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.7.1.tgz#bb3682c2c791ac90e7c6210b26478a8da085c359"
+
+typescript@^2.7.1, typescript@^2.7.2:
+  version "2.7.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.7.2.tgz#2d615a1ef4aee4f574425cdff7026edf81919836"
 
 uglify-js@^2.6, uglify-js@^2.6.1, uglify-js@^2.8.29:
   version "2.8.29"
@@ -5348,6 +5389,10 @@ unset-value@^1.0.0:
     has-value "^0.3.1"
     isobject "^3.0.0"
 
+upath@^1.0.0:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/upath/-/upath-1.0.4.tgz#ee2321ba0a786c50973db043a50b7bcba822361d"
+
 urix@^0.1.0, urix@~0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/urix/-/urix-0.1.0.tgz#da937f7a62e21fec1fd18d49b35c2935067a6c72"
@@ -5385,7 +5430,7 @@ uuid@^3.0.0, uuid@^3.1.0:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.2.1.tgz#12c528bb9d58d0b9265d9a2f6f0fe8be17ff1f14"
 
-v8flags@^3.0.0, v8flags@^3.0.1:
+v8flags@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/v8flags/-/v8flags-3.0.1.tgz#dce8fc379c17d9f2c9e9ed78d89ce00052b1b76b"
   dependencies:
@@ -5536,10 +5581,10 @@ watchpack@^1.4.0:
     graceful-fs "^4.1.2"
 
 webpack-merge@^4.1.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/webpack-merge/-/webpack-merge-4.1.1.tgz#f1197a0a973e69c6fbeeb6d658219aa8c0c13555"
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/webpack-merge/-/webpack-merge-4.1.2.tgz#5d372dddd3e1e5f8874f5bf5a8e929db09feb216"
   dependencies:
-    lodash "^4.17.4"
+    lodash "^4.17.5"
 
 webpack-sources@^1.0.1:
   version "1.1.0"
@@ -5549,25 +5594,27 @@ webpack-sources@^1.0.1:
     source-map "~0.6.1"
 
 webpack-stream@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/webpack-stream/-/webpack-stream-4.0.0.tgz#f3673dd907d6d9b1ea7bf51fcd1db85b5fd9e0f2"
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/webpack-stream/-/webpack-stream-4.0.2.tgz#7b90aec71d45c8a4519ff8b5a4d59e039cfd02c0"
   dependencies:
-    gulp-util "^3.0.7"
+    fancy-log "^1.3.2"
     lodash.clone "^4.3.2"
     lodash.some "^4.2.2"
     memory-fs "^0.4.1"
+    plugin-error "^1.0.1"
+    supports-color "^5.2.0"
     through "^2.3.8"
     vinyl "^2.1.0"
     webpack "^3.4.1"
 
 webpack@^3.4.1, webpack@^3.8.1:
-  version "3.10.0"
-  resolved "https://registry.yarnpkg.com/webpack/-/webpack-3.10.0.tgz#5291b875078cf2abf42bdd23afe3f8f96c17d725"
+  version "3.11.0"
+  resolved "https://registry.yarnpkg.com/webpack/-/webpack-3.11.0.tgz#77da451b1d7b4b117adaf41a1a93b5742f24d894"
   dependencies:
     acorn "^5.0.0"
     acorn-dynamic-import "^2.0.0"
-    ajv "^5.1.5"
-    ajv-keywords "^2.0.0"
+    ajv "^6.1.0"
+    ajv-keywords "^3.1.0"
     async "^2.1.2"
     enhanced-resolve "^3.4.0"
     escope "^3.6.0"


### PR DESCRIPTION
- **[Breaking change]** Rename `buffer` to `bytes` (`BufferType` to `BytesType`, `fromBuffer` to `fromBytes`, etc.) 
- **[Breaking change]** Rename `kryo/types` to `kryo/core` to avoid confusion with the `types` directory.
- **[Breaking change]** Make `.testError` optional.
- **[Feature]** Add `Ord` interface for types supporting comparison. Implement it to provide total order for float64, integer, date, bytes and boolean.
- **[Feature]** Add `$Bytes` and `$Ucs2String` builtins.
- **[Internal]** Remove unused `json` namespaces.
- **[Internal]** Update dependencies