### PR TITLE
Release v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Next
+# 0.8.0 (2018-12-03)
 
 - **[Breaking change]** Change `variantRead` result from `[variant, value]` to `{variant, value}`.
 - **[Breaking change]** Require `unorm` is `CodepointString` constructor.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kryo",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Runtime types",
   "main": "dist/lib/index",
   "types": "dist/lib/index.d.ts",


### PR DESCRIPTION
- **[Breaking change]** Change `variantRead` result from `[variant, value]` to `{variant, value}`.
- **[Breaking change]** Require `unorm` is `CodepointString` constructor.
- **[Feature]** Update to Typescript 3.2.
- **[Feature]** First class ESM support.
- **[Fix]** Replace fake property assignations by property existence assertions.
- **[Internal]** Update dependencies.