### PR TITLE
Release v0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Next
+# 0.9.0 (2020-04-04)
 
 - **[Breaking change]** Require Node `13.7`.
 - **[Breaking change]** Publish the library as ESM.


### PR DESCRIPTION
- **[Breaking change]** Require Node `13.7`.
- **[Breaking change]** Publish the library as ESM.
- **[Fix]** Update dependencies.
- **[Fix]** Update build tools.
- **[Internal]** Drop Gulp dependency.