### PR TITLE
Release v0.11.0

### DIFF
--- a/packages/kryo-bson/CHANGELOG.md
+++ b/packages/kryo-bson/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Next
+# 0.11.0 (2020-06-01)
 
 - **[Breaking change]** Require Node 14.
 

--- a/packages/kryo-bson/package.json
+++ b/packages/kryo-bson/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kryo-bson",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "BSON serializer for Kryo types",
   "license": "MIT",
   "keywords": [],

--- a/packages/kryo-json/CHANGELOG.md
+++ b/packages/kryo-json/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Next
+# 0.11.0 (2020-06-01)
 
 - **[Breaking change]** Require Node 14.
 

--- a/packages/kryo-json/package.json
+++ b/packages/kryo-json/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kryo-json",
-  "version": "0.10.2",
+  "version": "0.11.0",
   "description": "JSON serializer for Kryo types",
   "license": "MIT",
   "keywords": [],

--- a/packages/kryo-qs/CHANGELOG.md
+++ b/packages/kryo-qs/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Next
+# 0.11.0 (2020-06-01)
 
 - **[Breaking change]** Require Node 14.
 

--- a/packages/kryo-qs/package.json
+++ b/packages/kryo-qs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kryo-qs",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "Querystring serializer for Kryo types",
   "license": "MIT",
   "keywords": [],

--- a/packages/kryo-testing/CHANGELOG.md
+++ b/packages/kryo-testing/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Next
+# 0.11.0 (2020-06-01)
 
 - **[Breaking change]** Require Node 14.
 

--- a/packages/kryo-testing/package.json
+++ b/packages/kryo-testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kryo-testing",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "Helpers to test Kryo types and serializers",
   "license": "MIT",
   "keywords": [],

--- a/packages/kryo/CHANGELOG.md
+++ b/packages/kryo/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Next
+# 0.11.0 (2020-06-01)
 
 - **[Breaking change]** Require Node 14.
 - **[Breaking change]** Type `test` and `testError` argument as `unknown`.

--- a/packages/kryo/package.json
+++ b/packages/kryo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kryo",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "Runtime types for validation and serialization",
   "license": "MIT",
   "keywords": [],


### PR DESCRIPTION
- **[Breaking change]** Require Node 14.
- **[Breaking change]** Type `test` and `testError` argument as `unknown`.
- **[Fix]** Fix compilation error with TypeScript 3.9.
- **[Fix]** Update dependencies