### PR TITLE
Release v0.13.0

### DIFF
--- a/packages/kryo-bson/CHANGELOG.md
+++ b/packages/kryo-bson/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.13.0 (2021-07-20)
+
+- **[Breaking change]** Drop `lib` prefix from deep imports.
+
 # 0.12.2 (2021-06-29)
 
 - **[Fix]** Update to `kryo@0.12.2` with support for more `Ord` implementations.

--- a/packages/kryo-bson/package.json
+++ b/packages/kryo-bson/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kryo-bson",
-  "version": "0.12.2",
+  "version": "0.13.0",
   "description": "BSON serializer for Kryo types",
   "license": "MIT",
   "keywords": [],

--- a/packages/kryo-bson/package.json
+++ b/packages/kryo-bson/package.json
@@ -15,7 +15,14 @@
     "./src/lib/"
   ],
   "exports": {
-    "./lib/*": "./lib/*.js"
+    "./*": "./lib/*.js"
+  },
+  "typesVersions": {
+    "*": {
+      "*": [
+        "./lib/*"
+      ]
+    }
   },
   "scripts": {
     "lint": "eslint \"./src/**/*.ts\"",

--- a/packages/kryo-bson/src/lib/bson-value-reader.ts
+++ b/packages/kryo-bson/src/lib/bson-value-reader.ts
@@ -5,8 +5,8 @@
 import { Binary } from "bson";
 import incident from "incident";
 import { Reader, ReadVisitor } from "kryo";
-import { createInvalidTypeError } from "kryo/lib/errors/invalid-type";
-import { JsonReader } from "kryo-json/lib/json-reader";
+import { createInvalidTypeError } from "kryo/errors/invalid-type";
+import { JsonReader } from "kryo-json/json-reader";
 
 function isBinary(val: any): val is Binary {
   return val._bsontype === "Binary";

--- a/packages/kryo-bson/src/lib/bson-value-writer.ts
+++ b/packages/kryo-bson/src/lib/bson-value-writer.ts
@@ -4,8 +4,8 @@
 
 import { Binary } from "bson";
 import { Writer } from "kryo";
-import { StructuredWriter } from "kryo/lib/writers/structured";
-import { JsonWriter } from "kryo-json/lib/json-writer";
+import { StructuredWriter } from "kryo/writers/structured";
+import { JsonWriter } from "kryo-json/json-writer";
 
 export class BsonValueWriter extends StructuredWriter {
   constructor() {

--- a/packages/kryo-bson/src/test/types/literal.spec.ts
+++ b/packages/kryo-bson/src/test/types/literal.spec.ts
@@ -1,6 +1,6 @@
-import { LiteralIoType, LiteralType } from "kryo/lib/literal";
-import { TsEnumType } from "kryo/lib/ts-enum";
-import { Ucs2StringType } from "kryo/lib/ucs2-string";
+import { LiteralIoType, LiteralType } from "kryo/literal";
+import { TsEnumType } from "kryo/ts-enum";
+import { Ucs2StringType } from "kryo/ucs2-string";
 import { registerErrMochaTests, registerMochaSuites, TestItem } from "kryo-testing";
 
 import { BsonReader } from "../../lib/bson-reader.js";

--- a/packages/kryo-json/CHANGELOG.md
+++ b/packages/kryo-json/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.13.0 (2021-07-20)
+
+- **[Breaking change]** Drop `lib` prefix from deep imports.
+
 # 0.12.2 (2021-06-29)
 
 - **[Fix]** Update to `kryo@0.12.2` with support for more `Ord` implementations.

--- a/packages/kryo-json/package.json
+++ b/packages/kryo-json/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kryo-json",
-  "version": "0.12.2",
+  "version": "0.13.0",
   "description": "JSON serializer for Kryo types",
   "license": "MIT",
   "keywords": [],

--- a/packages/kryo-json/package.json
+++ b/packages/kryo-json/package.json
@@ -15,7 +15,14 @@
     "./src/lib/"
   ],
   "exports": {
-    "./lib/*": "./lib/*.js"
+    "./*": "./lib/*.js"
+  },
+  "typesVersions": {
+    "*": {
+      "*": [
+        "./lib/*"
+      ]
+    }
   },
   "scripts": {
     "lint": "eslint \"./src/**/*.ts\"",

--- a/packages/kryo-json/src/lib/json-value-reader.ts
+++ b/packages/kryo-json/src/lib/json-value-reader.ts
@@ -4,7 +4,7 @@
 
 import incident from "incident";
 import { Reader, ReadVisitor } from "kryo";
-import { createInvalidTypeError } from "kryo/lib/errors/invalid-type";
+import { createInvalidTypeError } from "kryo/errors/invalid-type";
 
 import { JsonValue } from "./json-value.js";
 

--- a/packages/kryo-json/src/lib/json-value-writer.ts
+++ b/packages/kryo-json/src/lib/json-value-writer.ts
@@ -3,7 +3,7 @@
  */
 
 import { Writer } from "kryo";
-import { StructuredWriter } from "kryo/lib/writers/structured";
+import { StructuredWriter } from "kryo/writers/structured";
 
 export class JsonValueWriter extends StructuredWriter {
   writeFloat64(value: number): number | string {

--- a/packages/kryo-json/src/test/types/any.spec.ts
+++ b/packages/kryo-json/src/test/types/any.spec.ts
@@ -1,6 +1,6 @@
 import chai from "chai";
-import { AnyType } from "kryo/lib/any";
-import { RecordIoType, RecordType } from "kryo/lib/record";
+import { AnyType } from "kryo/any";
+import { RecordIoType, RecordType } from "kryo/record";
 
 import { JsonReader } from "../../lib/json-reader.js";
 import { JsonValueReader } from "../../lib/json-value-reader.js";

--- a/packages/kryo-json/src/test/types/array.spec.ts
+++ b/packages/kryo-json/src/test/types/array.spec.ts
@@ -1,6 +1,6 @@
-import { ArrayIoType, ArrayType } from "kryo/lib/array";
-import { $Boolean } from "kryo/lib/boolean";
-import { $Uint8, IntegerType } from "kryo/lib/integer";
+import { ArrayIoType, ArrayType } from "kryo/array";
+import { $Boolean } from "kryo/boolean";
+import { $Uint8, IntegerType } from "kryo/integer";
 import { registerErrMochaTests, registerMochaSuites, TestItem } from "kryo-testing";
 
 import { JSON_READER } from "../../lib/json-reader.js";

--- a/packages/kryo-json/src/test/types/boolean.spec.ts
+++ b/packages/kryo-json/src/test/types/boolean.spec.ts
@@ -1,4 +1,4 @@
-import { $Boolean } from "kryo/lib/boolean";
+import { $Boolean } from "kryo/boolean";
 import { registerErrMochaTests, registerMochaSuites, TestItem } from "kryo-testing";
 
 import { JSON_READER } from "../../lib/json-reader.js";

--- a/packages/kryo-json/src/test/types/bytes.spec.ts
+++ b/packages/kryo-json/src/test/types/bytes.spec.ts
@@ -1,4 +1,4 @@
-import { BytesType } from "kryo/lib/bytes";
+import { BytesType } from "kryo/bytes";
 import { registerErrMochaTests, registerMochaSuites, TestItem } from "kryo-testing";
 
 import { JSON_READER } from "../../lib/json-reader.js";

--- a/packages/kryo-json/src/test/types/codepoint-string.spec.ts
+++ b/packages/kryo-json/src/test/types/codepoint-string.spec.ts
@@ -1,4 +1,4 @@
-import { CodepointStringType } from "kryo/lib/codepoint-string";
+import { CodepointStringType } from "kryo/codepoint-string";
 import { registerErrMochaTests, registerMochaSuites, TestItem } from "kryo-testing";
 import unorm from "unorm";
 

--- a/packages/kryo-json/src/test/types/custom.spec.ts
+++ b/packages/kryo-json/src/test/types/custom.spec.ts
@@ -1,8 +1,8 @@
 import incident from "incident";
 import { Reader, Writer } from "kryo";
-import { CustomType } from "kryo/lib/custom";
-import { createInvalidTypeError } from "kryo/lib/errors/invalid-type";
-import { readVisitor } from "kryo/lib/readers/read-visitor";
+import { CustomType } from "kryo/custom";
+import { createInvalidTypeError } from "kryo/errors/invalid-type";
+import { readVisitor } from "kryo/readers/read-visitor";
 import { registerErrMochaTests, registerMochaSuites, TestItem } from "kryo-testing";
 
 import { JSON_READER } from "../../lib/json-reader.js";

--- a/packages/kryo-json/src/test/types/date.spec.ts
+++ b/packages/kryo-json/src/test/types/date.spec.ts
@@ -1,4 +1,4 @@
-import { DateType } from "kryo/lib/date";
+import { DateType } from "kryo/date";
 import { registerErrMochaTests, registerMochaSuites, TestItem } from "kryo-testing";
 
 import { JSON_READER } from "../../lib/json-reader.js";

--- a/packages/kryo-json/src/test/types/float64.spec.ts
+++ b/packages/kryo-json/src/test/types/float64.spec.ts
@@ -1,4 +1,4 @@
-import { Float64Type } from "kryo/lib/float64";
+import { Float64Type } from "kryo/float64";
 import { registerErrMochaTests, registerMochaSuites, TestItem } from "kryo-testing";
 
 import { JSON_READER } from "../../lib/json-reader.js";

--- a/packages/kryo-json/src/test/types/integer.spec.ts
+++ b/packages/kryo-json/src/test/types/integer.spec.ts
@@ -1,4 +1,4 @@
-import { IntegerType } from "kryo/lib/integer";
+import { IntegerType } from "kryo/integer";
 import { registerErrMochaTests, registerMochaSuites, TestItem } from "kryo-testing";
 
 import { JSON_READER } from "../../lib/json-reader.js";

--- a/packages/kryo-json/src/test/types/literal.spec.ts
+++ b/packages/kryo-json/src/test/types/literal.spec.ts
@@ -1,6 +1,6 @@
-import { LiteralIoType, LiteralType } from "kryo/lib/literal";
-import { TsEnumType } from "kryo/lib/ts-enum";
-import { Ucs2StringType } from "kryo/lib/ucs2-string";
+import { LiteralIoType, LiteralType } from "kryo/literal";
+import { TsEnumType } from "kryo/ts-enum";
+import { Ucs2StringType } from "kryo/ucs2-string";
 import { registerErrMochaTests, registerMochaSuites, TestItem } from "kryo-testing";
 
 import { JSON_READER } from "../../lib/json-reader.js";

--- a/packages/kryo-json/src/test/types/map.spec.ts
+++ b/packages/kryo-json/src/test/types/map.spec.ts
@@ -1,6 +1,6 @@
-import { IntegerType } from "kryo/lib/integer";
-import { MapType } from "kryo/lib/map";
-import { Ucs2StringType } from "kryo/lib/ucs2-string";
+import { IntegerType } from "kryo/integer";
+import { MapType } from "kryo/map";
+import { Ucs2StringType } from "kryo/ucs2-string";
 import { registerErrMochaTests, registerMochaSuites, TestItem } from "kryo-testing";
 
 import { JSON_READER } from "../../lib/json-reader.js";

--- a/packages/kryo-json/src/test/types/record.spec.ts
+++ b/packages/kryo-json/src/test/types/record.spec.ts
@@ -1,7 +1,7 @@
 import { CaseStyle } from "kryo";
-import { DateType } from "kryo/lib/date";
-import { IntegerType } from "kryo/lib/integer";
-import { RecordIoType, RecordType } from "kryo/lib/record";
+import { DateType } from "kryo/date";
+import { IntegerType } from "kryo/integer";
+import { RecordIoType, RecordType } from "kryo/record";
 import { registerErrMochaTests, registerMochaSuites, TestItem } from "kryo-testing";
 
 import { JSON_READER } from "../../lib/json-reader.js";

--- a/packages/kryo-json/src/test/types/set.spec.ts
+++ b/packages/kryo-json/src/test/types/set.spec.ts
@@ -1,6 +1,6 @@
-import { $Boolean } from "kryo/lib/boolean";
-import { $Uint8, IntegerType } from "kryo/lib/integer";
-import { SetType } from "kryo/lib/set";
+import { $Boolean } from "kryo/boolean";
+import { $Uint8, IntegerType } from "kryo/integer";
+import { SetType } from "kryo/set";
 import { registerErrMochaTests, registerMochaSuites, TestItem } from "kryo-testing";
 
 import { JSON_READER } from "../../lib/json-reader.js";

--- a/packages/kryo-json/src/test/types/tagged-union.spec.ts
+++ b/packages/kryo-json/src/test/types/tagged-union.spec.ts
@@ -1,9 +1,9 @@
 import { CaseStyle } from "kryo";
-import { IntegerType } from "kryo/lib/integer";
-import { LiteralType } from "kryo/lib/literal";
-import { RecordType } from "kryo/lib/record";
-import { TaggedUnionType } from "kryo/lib/tagged-union";
-import { TsEnumType } from "kryo/lib/ts-enum";
+import { IntegerType } from "kryo/integer";
+import { LiteralType } from "kryo/literal";
+import { RecordType } from "kryo/record";
+import { TaggedUnionType } from "kryo/tagged-union";
+import { TsEnumType } from "kryo/ts-enum";
 import { registerErrMochaTests, registerMochaSuites, TestItem } from "kryo-testing";
 
 import { JSON_READER } from "../../lib/json-reader.js";

--- a/packages/kryo-json/src/test/types/try-union.spec.ts
+++ b/packages/kryo-json/src/test/types/try-union.spec.ts
@@ -1,7 +1,7 @@
 import { CaseStyle } from "kryo";
-import { IntegerType } from "kryo/lib/integer";
-import { RecordType } from "kryo/lib/record";
-import { TryUnionType } from "kryo/lib/try-union";
+import { IntegerType } from "kryo/integer";
+import { RecordType } from "kryo/record";
+import { TryUnionType } from "kryo/try-union";
 import { registerErrMochaTests, registerMochaSuites, TestItem } from "kryo-testing";
 
 import { JSON_READER } from "../../lib/json-reader.js";

--- a/packages/kryo-json/src/test/types/ts-enum.spec.ts
+++ b/packages/kryo-json/src/test/types/ts-enum.spec.ts
@@ -1,5 +1,5 @@
 import { CaseStyle } from "kryo";
-import { TsEnumType } from "kryo/lib/ts-enum";
+import { TsEnumType } from "kryo/ts-enum";
 import { registerErrMochaTests, registerMochaSuites, TestItem } from "kryo-testing";
 
 import { JSON_READER } from "../../lib/json-reader.js";

--- a/packages/kryo-json/src/test/types/ucs2-string.spec.ts
+++ b/packages/kryo-json/src/test/types/ucs2-string.spec.ts
@@ -1,4 +1,4 @@
-import { Ucs2StringType } from "kryo/lib/ucs2-string";
+import { Ucs2StringType } from "kryo/ucs2-string";
 import { registerErrMochaTests, registerMochaSuites, TestItem } from "kryo-testing";
 
 import { JSON_READER } from "../../lib/json-reader.js";

--- a/packages/kryo-json/src/test/types/white-list.spec.ts
+++ b/packages/kryo-json/src/test/types/white-list.spec.ts
@@ -1,5 +1,5 @@
-import { Ucs2StringType } from "kryo/lib/ucs2-string";
-import { WhiteListType } from "kryo/lib/white-list";
+import { Ucs2StringType } from "kryo/ucs2-string";
+import { WhiteListType } from "kryo/white-list";
 import { registerErrMochaTests, registerMochaSuites, TestItem } from "kryo-testing";
 
 import { JSON_READER } from "../../lib/json-reader.js";

--- a/packages/kryo-qs/CHANGELOG.md
+++ b/packages/kryo-qs/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.13.0 (2021-07-20)
+
+- **[Breaking change]** Drop `lib` prefix from deep imports.
+
 # 0.12.2 (2021-06-29)
 
 - **[Fix]** Update to `kryo@0.12.2` with support for more `Ord` implementations.

--- a/packages/kryo-qs/package.json
+++ b/packages/kryo-qs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kryo-qs",
-  "version": "0.12.2",
+  "version": "0.13.0",
   "description": "Querystring serializer for Kryo types",
   "license": "MIT",
   "keywords": [],

--- a/packages/kryo-qs/package.json
+++ b/packages/kryo-qs/package.json
@@ -15,7 +15,14 @@
     "./src/lib/"
   ],
   "exports": {
-    "./lib/*": "./lib/*.js"
+    "./*": "./lib/*.js"
+  },
+  "typesVersions": {
+    "*": {
+      "*": [
+        "./lib/*"
+      ]
+    }
   },
   "scripts": {
     "lint": "eslint \"./src/**/*.ts\"",

--- a/packages/kryo-qs/src/lib/qs-value-reader.ts
+++ b/packages/kryo-qs/src/lib/qs-value-reader.ts
@@ -4,8 +4,8 @@
 
 import incident from "incident";
 import { Reader, ReadVisitor } from "kryo";
-import { createInvalidTypeError } from "kryo/lib/errors/invalid-type";
-import { JsonReader } from "kryo-json/lib/json-reader";
+import { createInvalidTypeError } from "kryo/errors/invalid-type";
+import { JsonReader } from "kryo-json/json-reader";
 
 export class QsValueReader implements Reader<any> {
   trustInput?: boolean | undefined;

--- a/packages/kryo-qs/src/lib/qs-value-writer.ts
+++ b/packages/kryo-qs/src/lib/qs-value-writer.ts
@@ -3,8 +3,8 @@
  */
 
 import { Writer } from "kryo";
-import { StructuredWriter } from "kryo/lib/writers/structured";
-import { JsonWriter } from "kryo-json/lib/json-writer";
+import { StructuredWriter } from "kryo/writers/structured";
+import { JsonWriter } from "kryo-json/json-writer";
 
 export class QsValueWriter extends StructuredWriter {
   writeBoolean(value: boolean): "true" | "false" {

--- a/packages/kryo-qs/src/test/types/any.spec.ts
+++ b/packages/kryo-qs/src/test/types/any.spec.ts
@@ -1,6 +1,6 @@
 import chai from "chai";
-import { AnyType } from "kryo/lib/any";
-import { RecordIoType, RecordType } from "kryo/lib/record";
+import { AnyType } from "kryo/any";
+import { RecordIoType, RecordType } from "kryo/record";
 
 import { QsReader } from "../../lib/qs-reader.js";
 import { QsValueReader } from "../../lib/qs-value-reader.js";

--- a/packages/kryo-qs/src/test/types/array.spec.ts
+++ b/packages/kryo-qs/src/test/types/array.spec.ts
@@ -1,6 +1,6 @@
-import { ArrayIoType, ArrayType } from "kryo/lib/array";
-import { $Boolean } from "kryo/lib/boolean";
-import { $Uint8, IntegerType } from "kryo/lib/integer";
+import { ArrayIoType, ArrayType } from "kryo/array";
+import { $Boolean } from "kryo/boolean";
+import { $Uint8, IntegerType } from "kryo/integer";
 import { registerErrMochaTests, registerMochaSuites, TestItem } from "kryo-testing";
 
 import { QsReader } from "../../lib/qs-reader.js";

--- a/packages/kryo-qs/src/test/types/boolean.spec.ts
+++ b/packages/kryo-qs/src/test/types/boolean.spec.ts
@@ -1,4 +1,4 @@
-import { BooleanType } from "kryo/lib/boolean";
+import { BooleanType } from "kryo/boolean";
 import { registerErrMochaTests, registerMochaSuites, TestItem } from "kryo-testing";
 
 import { QsReader } from "../../lib/qs-reader.js";

--- a/packages/kryo-qs/src/test/types/bytes.spec.ts
+++ b/packages/kryo-qs/src/test/types/bytes.spec.ts
@@ -1,4 +1,4 @@
-import { BytesType } from "kryo/lib/bytes";
+import { BytesType } from "kryo/bytes";
 import { registerErrMochaTests, registerMochaSuites, TestItem } from "kryo-testing";
 
 import { QsReader } from "../../lib/qs-reader.js";

--- a/packages/kryo-qs/src/test/types/codepoint-string.spec.ts
+++ b/packages/kryo-qs/src/test/types/codepoint-string.spec.ts
@@ -1,4 +1,4 @@
-import { CodepointStringType } from "kryo/lib/codepoint-string";
+import { CodepointStringType } from "kryo/codepoint-string";
 import { registerErrMochaTests, registerMochaSuites, TestItem } from "kryo-testing";
 import unorm from "unorm";
 

--- a/packages/kryo-qs/src/test/types/custom.spec.ts
+++ b/packages/kryo-qs/src/test/types/custom.spec.ts
@@ -1,8 +1,8 @@
 import incident from "incident";
 import { Reader, Writer } from "kryo";
-import { CustomType } from "kryo/lib/custom";
-import { createInvalidTypeError } from "kryo/lib/errors/invalid-type";
-import { readVisitor } from "kryo/lib/readers/read-visitor";
+import { CustomType } from "kryo/custom";
+import { createInvalidTypeError } from "kryo/errors/invalid-type";
+import { readVisitor } from "kryo/readers/read-visitor";
 import { registerErrMochaTests, registerMochaSuites, TestItem } from "kryo-testing";
 
 import { QsReader } from "../../lib/qs-reader.js";

--- a/packages/kryo-qs/src/test/types/date.spec.ts
+++ b/packages/kryo-qs/src/test/types/date.spec.ts
@@ -1,4 +1,4 @@
-import { DateType } from "kryo/lib/date";
+import { DateType } from "kryo/date";
 import { registerErrMochaTests, registerMochaSuites, TestItem } from "kryo-testing";
 
 import { QsReader } from "../../lib/qs-reader.js";

--- a/packages/kryo-qs/src/test/types/float64.spec.ts
+++ b/packages/kryo-qs/src/test/types/float64.spec.ts
@@ -1,4 +1,4 @@
-import { Float64Type } from "kryo/lib/float64";
+import { Float64Type } from "kryo/float64";
 import { registerErrMochaTests, registerMochaSuites, TestItem } from "kryo-testing";
 
 import { QsReader } from "../../lib/qs-reader.js";

--- a/packages/kryo-qs/src/test/types/integer.spec.ts
+++ b/packages/kryo-qs/src/test/types/integer.spec.ts
@@ -1,4 +1,4 @@
-import { IntegerType } from "kryo/lib/integer";
+import { IntegerType } from "kryo/integer";
 import { registerErrMochaTests, registerMochaSuites, TestItem } from "kryo-testing";
 
 import { QsReader } from "../../lib/qs-reader.js";

--- a/packages/kryo-qs/src/test/types/literal.spec.ts
+++ b/packages/kryo-qs/src/test/types/literal.spec.ts
@@ -1,6 +1,6 @@
-import { LiteralIoType, LiteralType } from "kryo/lib/literal";
-import { TsEnumType } from "kryo/lib/ts-enum";
-import { Ucs2StringType } from "kryo/lib/ucs2-string";
+import { LiteralIoType, LiteralType } from "kryo/literal";
+import { TsEnumType } from "kryo/ts-enum";
+import { Ucs2StringType } from "kryo/ucs2-string";
 import { registerErrMochaTests, registerMochaSuites, TestItem } from "kryo-testing";
 
 import { QsReader } from "../../lib/qs-reader.js";

--- a/packages/kryo-qs/src/test/types/map.spec.ts
+++ b/packages/kryo-qs/src/test/types/map.spec.ts
@@ -1,6 +1,6 @@
-import { IntegerType } from "kryo/lib/integer";
-import { MapType } from "kryo/lib/map";
-import { Ucs2StringType } from "kryo/lib/ucs2-string";
+import { IntegerType } from "kryo/integer";
+import { MapType } from "kryo/map";
+import { Ucs2StringType } from "kryo/ucs2-string";
 import { registerErrMochaTests, registerMochaSuites, TestItem } from "kryo-testing";
 
 import { QsReader } from "../../lib/qs-reader.js";

--- a/packages/kryo-qs/src/test/types/record.spec.ts
+++ b/packages/kryo-qs/src/test/types/record.spec.ts
@@ -1,7 +1,7 @@
 import { CaseStyle } from "kryo";
-import { DateType } from "kryo/lib/date";
-import { IntegerType } from "kryo/lib/integer";
-import { RecordIoType, RecordType } from "kryo/lib/record";
+import { DateType } from "kryo/date";
+import { IntegerType } from "kryo/integer";
+import { RecordIoType, RecordType } from "kryo/record";
 import { registerErrMochaTests, registerMochaSuites, TestItem } from "kryo-testing";
 
 import { QsReader } from "../../lib/qs-reader.js";

--- a/packages/kryo-qs/src/test/types/tagged-union.spec.ts
+++ b/packages/kryo-qs/src/test/types/tagged-union.spec.ts
@@ -1,9 +1,9 @@
 import { CaseStyle } from "kryo";
-import { IntegerType } from "kryo/lib/integer";
-import { LiteralType } from "kryo/lib/literal";
-import { RecordType } from "kryo/lib/record";
-import { TaggedUnionType } from "kryo/lib/tagged-union";
-import { TsEnumType } from "kryo/lib/ts-enum";
+import { IntegerType } from "kryo/integer";
+import { LiteralType } from "kryo/literal";
+import { RecordType } from "kryo/record";
+import { TaggedUnionType } from "kryo/tagged-union";
+import { TsEnumType } from "kryo/ts-enum";
 import { registerErrMochaTests, registerMochaSuites, TestItem } from "kryo-testing";
 
 import { QsReader } from "../../lib/qs-reader.js";

--- a/packages/kryo-qs/src/test/types/try-union.spec.ts
+++ b/packages/kryo-qs/src/test/types/try-union.spec.ts
@@ -1,7 +1,7 @@
 import { CaseStyle } from "kryo";
-import { IntegerType } from "kryo/lib/integer";
-import { RecordType } from "kryo/lib/record";
-import { TryUnionType } from "kryo/lib/try-union";
+import { IntegerType } from "kryo/integer";
+import { RecordType } from "kryo/record";
+import { TryUnionType } from "kryo/try-union";
 import { registerErrMochaTests, registerMochaSuites, TestItem } from "kryo-testing";
 
 import { QsReader } from "../../lib/qs-reader.js";

--- a/packages/kryo-qs/src/test/types/ts-enum.spec.ts
+++ b/packages/kryo-qs/src/test/types/ts-enum.spec.ts
@@ -1,5 +1,5 @@
 import { CaseStyle } from "kryo";
-import { TsEnumType } from "kryo/lib/ts-enum";
+import { TsEnumType } from "kryo/ts-enum";
 import { registerErrMochaTests, registerMochaSuites, TestItem } from "kryo-testing";
 
 import { QsReader } from "../../lib/qs-reader.js";

--- a/packages/kryo-qs/src/test/types/ucs2-string.spec.ts
+++ b/packages/kryo-qs/src/test/types/ucs2-string.spec.ts
@@ -1,4 +1,4 @@
-import { Ucs2StringType } from "kryo/lib/ucs2-string";
+import { Ucs2StringType } from "kryo/ucs2-string";
 import { registerErrMochaTests, registerMochaSuites, TestItem } from "kryo-testing";
 
 import { QsReader } from "../../lib/qs-reader.js";

--- a/packages/kryo-qs/src/test/types/white-list.spec.ts
+++ b/packages/kryo-qs/src/test/types/white-list.spec.ts
@@ -1,5 +1,5 @@
-import { Ucs2StringType } from "kryo/lib/ucs2-string";
-import { WhiteListType } from "kryo/lib/white-list";
+import { Ucs2StringType } from "kryo/ucs2-string";
+import { WhiteListType } from "kryo/white-list";
 import { registerErrMochaTests, registerMochaSuites, TestItem } from "kryo-testing";
 
 import { QsReader } from "../../lib/qs-reader.js";

--- a/packages/kryo-testing/CHANGELOG.md
+++ b/packages/kryo-testing/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.13.0 (2021-07-20)
+
+- **[Breaking change]** Drop `lib` prefix from deep imports.
+
 # 0.12.2 (2021-06-29)
 
 - **[Fix]** Update to `kryo@0.12.2` with support for more `Ord` implementations.

--- a/packages/kryo-testing/package.json
+++ b/packages/kryo-testing/package.json
@@ -14,10 +14,16 @@
     "./lib/",
     "./src/lib/"
   ],
-  "main": "./lib/index.js",
   "exports": {
     ".": "./lib/index.js",
-    "./lib/*": "./lib/*.js"
+    "./*": "./lib/*.js"
+  },
+  "typesVersions": {
+    "*": {
+      "*": [
+        "./lib/*"
+      ]
+    }
   },
   "scripts": {
     "lint": "eslint \"./src/**/*.ts\"",

--- a/packages/kryo-testing/package.json
+++ b/packages/kryo-testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kryo-testing",
-  "version": "0.12.2",
+  "version": "0.13.0",
   "description": "Helpers to test Kryo types and serializers",
   "license": "MIT",
   "keywords": [],

--- a/packages/kryo/CHANGELOG.md
+++ b/packages/kryo/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.13.0 (2021-07-20)
+
+- **[Breaking change]** Drop `lib` prefix from deep imports.
+
 # 0.12.2 (2021-06-29)
 
 - **[Fix]** Add `prepack` lifecycle script.

--- a/packages/kryo/package.json
+++ b/packages/kryo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kryo",
-  "version": "0.12.2",
+  "version": "0.13.0",
   "description": "Runtime types for validation and serialization",
   "license": "MIT",
   "keywords": [],

--- a/packages/kryo/package.json
+++ b/packages/kryo/package.json
@@ -10,15 +10,20 @@
     "url": "git://github.com/demurgos/kryo.git"
   },
   "type": "module",
-  "main": "./lib/index.js",
-  "module": "./lib/index.js",
   "files": [
     "./lib/",
     "./src/lib/"
   ],
   "exports": {
     ".": "./lib/index.js",
-    "./lib/*": "./lib/*.js"
+    "./*": "./lib/*.js"
+  },
+  "typesVersions": {
+    "*": {
+      "*": [
+        "./lib/*"
+      ]
+    }
   },
   "scripts": {
     "lint": "eslint \"./src/**/*.ts\"",


### PR DESCRIPTION
- **[Breaking change]** Drop `lib` prefix from deep imports.