### PR TITLE
Release v0.15.0

### DIFF
--- a/packages/kryo-bson/CHANGELOG.md
+++ b/packages/kryo-bson/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 0.15.0 (2024-01-22)
+
+- Drop `unorm`, `incident`, `object-inspect` errors
+- `CodePointString` renamed to `UsvString`
+  - `enforceUnicodeRegExp` for opt-out replaced by `allowUcs2String` for opt-in
+  - `normalization` defaults to `null` (instead of `NFC`)
+- `WhiteListType` renamed to `LiteralUnion`
+
 # 0.14.2 (2023-12-10)
 
 - **[Fix]** Update dependencies

--- a/packages/kryo-bson/package.json
+++ b/packages/kryo-bson/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kryo-bson",
-  "version": "0.14.2",
+  "version": "0.15.0",
   "description": "BSON serializer for Kryo types",
   "license": "MIT",
   "keywords": [],

--- a/packages/kryo-json/CHANGELOG.md
+++ b/packages/kryo-json/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 0.15.0 (2024-01-22)
+
+- Drop `unorm`, `incident`, `object-inspect` errors
+- `CodePointString` renamed to `UsvString`
+  - `enforceUnicodeRegExp` for opt-out replaced by `allowUcs2String` for opt-in
+  - `normalization` defaults to `null` (instead of `NFC`)
+- `WhiteListType` renamed to `LiteralUnion`
+
 # 0.14.2 (2023-12-10)
 
 - **[Fix]** Update dependencies

--- a/packages/kryo-json/package.json
+++ b/packages/kryo-json/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kryo-json",
-  "version": "0.14.2",
+  "version": "0.15.0",
   "description": "JSON serializer for Kryo types",
   "license": "MIT",
   "keywords": [],

--- a/packages/kryo-qs/CHANGELOG.md
+++ b/packages/kryo-qs/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 0.15.0 (2024-01-22)
+
+- Drop `unorm`, `incident`, `object-inspect` errors
+- `CodePointString` renamed to `UsvString`
+  - `enforceUnicodeRegExp` for opt-out replaced by `allowUcs2String` for opt-in
+  - `normalization` defaults to `null` (instead of `NFC`)
+- `WhiteListType` renamed to `LiteralUnion`
+
 # 0.14.2 (2023-12-10)
 
 - **[Fix]** Update dependencies

--- a/packages/kryo-qs/package.json
+++ b/packages/kryo-qs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kryo-qs",
-  "version": "0.14.2",
+  "version": "0.15.0",
   "description": "Querystring serializer for Kryo types",
   "license": "MIT",
   "keywords": [],

--- a/packages/kryo-testing/CHANGELOG.md
+++ b/packages/kryo-testing/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 0.15.0 (2024-01-22)
+
+- Drop `unorm`, `incident`, `object-inspect` errors
+- `CodePointString` renamed to `UsvString`
+  - `enforceUnicodeRegExp` for opt-out replaced by `allowUcs2String` for opt-in
+  - `normalization` defaults to `null` (instead of `NFC`)
+- `WhiteListType` renamed to `LiteralUnion`
+
 # 0.14.2 (2023-12-10)
 
 - **[Fix]** Update dependencies

--- a/packages/kryo-testing/package.json
+++ b/packages/kryo-testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kryo-testing",
-  "version": "0.14.2",
+  "version": "0.15.0",
   "description": "Helpers to test Kryo types and serializers",
   "license": "MIT",
   "keywords": [],

--- a/packages/kryo/CHANGELOG.md
+++ b/packages/kryo/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Next
+# 0.15.0 (2024-01-22)
 
 - Drop `unorm`, `incident`, `object-inspect` errors
 - `CodePointString` renamed to `UsvString`

--- a/packages/kryo/package.json
+++ b/packages/kryo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kryo",
-  "version": "0.14.2",
+  "version": "0.15.0",
   "description": "Runtime types for validation and serialization",
   "license": "MIT",
   "keywords": [],


### PR DESCRIPTION
- Drop `unorm`, `incident`, `object-inspect` errors
- `CodePointString` renamed to `UsvString`
  - `enforceUnicodeRegExp` for opt-out replaced by `allowUcs2String` for opt-in
  - `normalization` defaults to `null` (instead of `NFC`)
- `WhiteListType` renamed to `LiteralUnion`