### PR TITLE
feature: implement IO for `URLSearchParams`

### DIFF
--- a/packages/kryo-qs/.gitignore
+++ b/packages/kryo-qs/.gitignore
@@ -1,3 +1,0 @@
-/coverage/
-/lib/
-/test/

--- a/packages/kryo-qs/README.md
+++ b/packages/kryo-qs/README.md
@@ -1,3 +1,3 @@
 # kryo-qs
 
-Querystring serialization support for Kryo types.
+Querystring serialization support for Kryo types, through `qs`.

--- a/packages/kryo-search-params/CHANGELOG.md
+++ b/packages/kryo-search-params/CHANGELOG.md
@@ -1,0 +1,3 @@
+# Next
+
+- **[Feature]** First release.

--- a/packages/kryo-search-params/README.md
+++ b/packages/kryo-search-params/README.md
@@ -1,0 +1,3 @@
+# kryo-search-params
+
+Querystring serialization support for Kryo types, through standard `URLSearchParams`.

--- a/packages/kryo-search-params/package.json
+++ b/packages/kryo-search-params/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "kryo-qs",
+  "name": "kryo-search-params",
   "version": "0.15.0",
-  "description": "Querystring serializer for Kryo types, using `qs`",
+  "description": "Querystring serializer for Kryo types, using URLSearchParams",
   "license": "MIT",
   "keywords": [],
   "homepage": "https://demurgos.github.io/kryo",
@@ -21,14 +21,13 @@
     "node": ">=18.13.0"
   },
   "dependencies": {
-    "@types/qs": "^6.9.11",
     "kryo": "workspace:^",
-    "kryo-json": "workspace:^",
-    "qs": "^6.11.2"
+    "kryo-json": "workspace:^"
   },
   "devDependencies": {
     "@types/chai": "^4.3.11",
     "@types/mocha": "^10.0.6",
+    "@types/node": "^20.11.5",
     "chai": "^5.0.0",
     "kryo-testing": "workspace:^",
     "mocha": "^10.2.0",

--- a/packages/kryo-search-params/src/lib/search-params-reader.mts
+++ b/packages/kryo-search-params/src/lib/search-params-reader.mts
@@ -1,0 +1,105 @@
+import {CheckId, KryoContext, Reader, ReadVisitor, Result, writeError} from "kryo";
+import {SearchParamsValueReader} from "./search-params-value-reader.mjs";
+import {CheckKind} from "kryo/checks/check-kind";
+import {SearchParamsRootReader} from "./search-params-root-reader.mjs";
+
+export function parseSearch(searchStr: string): URLSearchParams {
+  return new URLSearchParams(searchStr);
+}
+
+export class SearchParamsReader implements Reader<string> {
+  public readonly trustInput?: boolean | undefined;
+  readonly #valueReader: SearchParamsValueReader;
+  readonly #rootReader: SearchParamsRootReader;
+  readonly #primitiveWrapper: string;
+
+  constructor(trust?: boolean, primitiveWrapper: string = "_") {
+    this.trustInput = trust;
+    this.#primitiveWrapper = primitiveWrapper;
+    this.#valueReader = new SearchParamsValueReader(trust);
+    this.#rootReader = new SearchParamsRootReader(trust);
+  }
+
+  readAny<T>(cx: KryoContext, raw: string, visitor: ReadVisitor<T>): Result<T, CheckId> {
+    const primitive: string | null = parseSearch(raw).get(this.#primitiveWrapper);
+    if (primitive === null) {
+      return writeError(cx, {check: CheckKind.BaseType, expected: ["Ucs2String", "UsvString"]})
+    } else {
+      return this.#valueReader.readAny(cx, primitive, visitor);
+    }
+  }
+
+  readBoolean<T>(cx: KryoContext, raw: string, visitor: ReadVisitor<T>): Result<T, CheckId> {
+    const primitive: string | null = parseSearch(raw).get(this.#primitiveWrapper);
+    if (primitive === null) {
+      return writeError(cx, {check: CheckKind.BaseType, expected: ["Ucs2String", "UsvString"]})
+    } else {
+      return this.#valueReader.readBoolean(cx, primitive, visitor);
+    }
+  }
+
+  readBytes<T>(cx: KryoContext, raw: string, visitor: ReadVisitor<T>): Result<T, CheckId> {
+    const primitive: string | null = parseSearch(raw).get(this.#primitiveWrapper);
+    if (primitive === null) {
+      return writeError(cx, {check: CheckKind.BaseType, expected: ["Ucs2String", "UsvString"]})
+    } else {
+      return this.#valueReader.readBytes(cx, primitive, visitor);
+    }
+  }
+
+  readDate<T>(cx: KryoContext, raw: string, visitor: ReadVisitor<T>): Result<T, CheckId> {
+    const primitive: string | null = parseSearch(raw).get(this.#primitiveWrapper);
+    if (primitive === null) {
+      return writeError(cx, {check: CheckKind.BaseType, expected: ["Ucs2String", "UsvString"]})
+    } else {
+      return this.#valueReader.readDate(cx, primitive, visitor);
+    }
+  }
+
+  readRecord<T>(cx: KryoContext, raw: string, visitor: ReadVisitor<T>): Result<T, CheckId> {
+    const sp = parseSearch(raw);
+    return this.#rootReader.readRecord(cx, sp, visitor);
+  }
+
+  readFloat64<T>(cx: KryoContext, raw: string, visitor: ReadVisitor<T>): Result<T, CheckId> {
+    const primitive: string | null = parseSearch(raw).get(this.#primitiveWrapper);
+    if (primitive === null) {
+      return writeError(cx, {check: CheckKind.BaseType, expected: ["Ucs2String", "UsvString"]})
+    } else {
+      return this.#valueReader.readFloat64(cx, primitive, visitor);
+    }
+  }
+
+  readList<T>(cx: KryoContext, raw: string, visitor: ReadVisitor<T>): Result<T, CheckId> {
+    const primitive: string | null = parseSearch(raw).get(this.#primitiveWrapper);
+    if (primitive === null) {
+      return writeError(cx, {check: CheckKind.BaseType, expected: ["Ucs2String", "UsvString"]})
+    } else {
+      return this.#valueReader.readList(cx, primitive, visitor);
+    }
+  }
+
+  readMap<T>(cx: KryoContext, raw: string, visitor: ReadVisitor<T>): Result<T, CheckId> {
+    return this.#rootReader.readMap(cx, parseSearch(raw), visitor);
+  }
+
+  readNull<T>(cx: KryoContext, raw: string, visitor: ReadVisitor<T>): Result<T, CheckId> {
+    const primitive: string | null = parseSearch(raw).get(this.#primitiveWrapper);
+    if (primitive === null) {
+      return writeError(cx, {check: CheckKind.BaseType, expected: ["Ucs2String", "UsvString"]})
+    } else {
+      return this.#valueReader.readNull(cx, primitive, visitor);
+    }
+  }
+
+  readString<T>(cx: KryoContext, raw: string, visitor: ReadVisitor<T>): Result<T, CheckId> {
+    const primitive: string | null = parseSearch(raw).get(this.#primitiveWrapper);
+    if (primitive === null) {
+      return writeError(cx, {check: CheckKind.BaseType, expected: ["Ucs2String", "UsvString"]})
+    } else {
+      return this.#valueReader.readString(cx, primitive, visitor);
+    }
+  }
+}
+
+export const SEARCH_PARAMS_READER: SearchParamsReader = new SearchParamsReader();

--- a/packages/kryo-search-params/src/lib/search-params-root-reader.mts
+++ b/packages/kryo-search-params/src/lib/search-params-root-reader.mts
@@ -1,0 +1,87 @@
+import {CheckId, KryoContext, Reader, ReadVisitor, Result, writeError} from "kryo";
+import {BaseTypeCheck} from "kryo/checks/base-type";
+import {CheckKind} from "kryo/checks/check-kind";
+import {PropertyKeyCheck} from "kryo/checks/property-key";
+import {SEARCH_PARAMS_VALUE_READER} from "./search-params-value-reader.mjs";
+import {JSON_VALUE_READER} from "kryo-json/json-value-reader";
+import {$Any} from "kryo/any";
+
+export class SearchParamsRootReader implements Reader<URLSearchParams> {
+  trustInput?: boolean | undefined;
+
+  constructor(trust?: boolean) {
+    this.trustInput = trust;
+  }
+
+  readAny<T>(cx: KryoContext, input: URLSearchParams, visitor: ReadVisitor<T>): Result<T, CheckId> {
+    const inputMap: Map<string, string> = new Map();
+    for (const [key, rawValue] of input.entries()) {
+      const {ok, value} = $Any.read(cx, SEARCH_PARAMS_VALUE_READER, rawValue);
+      if (ok) {
+        inputMap.set(key, value);
+      } else {
+        return {ok: false, value};
+      }
+    }
+    return visitor.fromMap(inputMap, SEARCH_PARAMS_VALUE_READER, JSON_VALUE_READER);
+  }
+
+  readBoolean<T>(cx: KryoContext, _input: URLSearchParams, _visitor: ReadVisitor<T>): Result<T, CheckId> {
+    return writeError(cx, {check: CheckKind.BaseType, expected: ["Record"]} satisfies BaseTypeCheck);
+  }
+
+  readBytes<T>(cx: KryoContext, _input: URLSearchParams, _visitor: ReadVisitor<T>): Result<T, CheckId> {
+    return writeError(cx, {check: CheckKind.BaseType, expected: ["Record"]} satisfies BaseTypeCheck);
+  }
+
+  readDate<T>(cx: KryoContext, _input: URLSearchParams, _visitor: ReadVisitor<T>): Result<T, CheckId> {
+    return writeError(cx, {check: CheckKind.BaseType, expected: ["Record"]} satisfies BaseTypeCheck);
+  }
+
+  readRecord<T>(cx: KryoContext, input: URLSearchParams, visitor: ReadVisitor<T>): Result<T, CheckId> {
+    if (typeof input !== "object" || input === null) {
+      return writeError(cx, {check: CheckKind.BaseType, expected: ["Record"]} satisfies BaseTypeCheck);
+    }
+    const inputMap: Map<string, string> = new Map(input.entries());
+    return visitor.fromMap(inputMap, JSON_VALUE_READER, SEARCH_PARAMS_VALUE_READER);
+  }
+
+  readFloat64<T>(cx: KryoContext, _input: URLSearchParams, _visitor: ReadVisitor<T>): Result<T, CheckId> {
+    return writeError(cx, {check: CheckKind.BaseType, expected: ["Record"]} satisfies BaseTypeCheck);
+  }
+
+  readList<T>(cx: KryoContext, _input: URLSearchParams, _visitor: ReadVisitor<T>): Result<T, CheckId> {
+    return writeError(cx, {check: CheckKind.BaseType, expected: ["Record"]} satisfies BaseTypeCheck);
+  }
+
+  readMap<T>(cx: KryoContext, input: URLSearchParams, visitor: ReadVisitor<T>): Result<T, CheckId> {
+    if (typeof input !== "object" || input === null) {
+      return writeError(cx, {check: CheckKind.BaseType, expected: ["Record"]} satisfies BaseTypeCheck);
+    }
+    const inputMap: Map<unknown, string> = new Map();
+    for (const [rawKey, rawValue] of input.entries()) {
+      let key: unknown;
+      try {
+        key = JSON.parse(rawKey);
+        // key = (/* keyType */ undefined as any).read(jsonReader, key);
+      } catch (err) {
+        if (!(err instanceof Error)) {
+          throw err;
+        }
+        return writeError(cx, {check: CheckKind.PropertyKey} satisfies PropertyKeyCheck);
+      }
+      inputMap.set(key, rawValue);
+    }
+    return visitor.fromMap(inputMap, JSON_VALUE_READER, SEARCH_PARAMS_VALUE_READER);
+  }
+
+  readNull<T>(cx: KryoContext, _input: URLSearchParams, _visitor: ReadVisitor<T>): Result<T, CheckId> {
+    return writeError(cx, {check: CheckKind.BaseType, expected: ["Record"]} satisfies BaseTypeCheck);
+  }
+
+  readString<T>(cx: KryoContext, _input: URLSearchParams, _visitor: ReadVisitor<T>): Result<T, CheckId> {
+    return writeError(cx, {check: CheckKind.BaseType, expected: ["Record"]} satisfies BaseTypeCheck);
+  }
+}
+
+export const SEARCH_PARAMS_ROOT_READER: SearchParamsRootReader = new SearchParamsRootReader();

--- a/packages/kryo-search-params/src/lib/search-params-value-reader.mts
+++ b/packages/kryo-search-params/src/lib/search-params-value-reader.mts
@@ -1,0 +1,99 @@
+import {CheckId, KryoContext, Reader, ReadVisitor, Result, writeError} from "kryo";
+import {BaseTypeCheck} from "kryo/checks/base-type";
+import {CheckKind} from "kryo/checks/check-kind";
+import {JSON_READER, JsonReader} from "kryo-json/json-reader";
+
+export class SearchParamsValueReader implements Reader<string> {
+  trustInput?: boolean | undefined;
+
+  constructor(trust?: boolean) {
+    this.trustInput = trust;
+  }
+
+  readAny<T>(cx: KryoContext, input: string, visitor: ReadVisitor<T>): Result<T, CheckId> {
+    return JSON_READER.readAny(cx, input, visitor);
+  }
+
+  readBoolean<T>(cx: KryoContext, input: string, visitor: ReadVisitor<T>): Result<T, CheckId> {
+    if (input !== "true" && input !== "false") {
+      return writeError(cx, {check: CheckKind.BaseType, expected: ["Boolean"]} satisfies BaseTypeCheck);
+    }
+    return visitor.fromBoolean(input === "true");
+  }
+
+  readBytes<T>(cx: KryoContext, input: string, visitor: ReadVisitor<T>): Result<T, CheckId> {
+    if (typeof input !== "string") {
+      return writeError(cx, {check: CheckKind.BaseType, expected: ["Ucs2String", "UsvString", "Bytes"]} satisfies BaseTypeCheck);
+    } else if (!/^(?:[0-9a-f]{2})*$/.test(input)) {
+      return writeError(cx, {check: CheckKind.BaseType, expected: ["Ucs2String", "UsvString", "Bytes"]} satisfies BaseTypeCheck);
+    }
+    const len: number = input.length / 2;
+    const result: Uint8Array = new Uint8Array(len);
+    for (let i: number = 0; i < len; i++) {
+      result[i] = parseInt(input.substring(2 * i, 2 * i + 2), 16);
+    }
+    return visitor.fromBytes(result);
+  }
+
+  readDate<T>(cx: KryoContext, input: string, visitor: ReadVisitor<T>): Result<T, CheckId> {
+    if (this.trustInput) {
+      return visitor.fromDate(new Date(input as number | string));
+    }
+
+    if (typeof input === "string") {
+      return visitor.fromDate(new Date(input));
+    }
+
+    return writeError(cx, {check: CheckKind.BaseType, expected: ["Ucs2String", "Float64", "Sint53", "UsvString"]} satisfies BaseTypeCheck);
+  }
+
+  readRecord<T>(cx: KryoContext, input: string, visitor: ReadVisitor<T>): Result<T, CheckId> {
+    const jsonReader: JsonReader = new JsonReader();
+    return jsonReader.readRecord(cx, input, visitor);
+  }
+
+  readFloat64<T>(cx: KryoContext, input: string, visitor: ReadVisitor<T>): Result<T, CheckId> {
+    const specialValues: Map<unknown, number> = new Map([
+      ["-0", -0],
+      ["NaN", NaN],
+      ["Infinity", Infinity],
+      ["+Infinity", Infinity],
+      ["-Infinity", -Infinity],
+    ]);
+    const special: number | undefined = specialValues.get(input);
+    if (special !== undefined) {
+      return visitor.fromFloat64(special);
+    } else if (typeof input === "string") {
+      return visitor.fromFloat64(parseFloat(input));
+    } else {
+      return writeError(cx, {check: CheckKind.BaseType, expected: ["Float64"]} satisfies BaseTypeCheck);
+    }
+  }
+
+  readList<T>(cx: KryoContext, input: string, visitor: ReadVisitor<T>): Result<T, CheckId> {
+    return JSON_READER.readList(cx, input, visitor);
+  }
+
+  readMap<T>(cx: KryoContext, input: string, visitor: ReadVisitor<T>): Result<T, CheckId> {
+    return JSON_READER.readMap(cx, input, visitor);
+  }
+
+  readNull<T>(cx: KryoContext, input: string, visitor: ReadVisitor<T>): Result<T, CheckId> {
+    if (this.trustInput) {
+      return visitor.fromNull();
+    }
+    if (input !== "") {
+      return writeError(cx, {check: CheckKind.BaseType, expected: ["Ucs2String", "UsvString"]} satisfies BaseTypeCheck);
+    }
+    return visitor.fromNull();
+  }
+
+  readString<T>(cx: KryoContext, input: string, visitor: ReadVisitor<T>): Result<T, CheckId> {
+    if (typeof input !== "string") {
+      return writeError(cx, {check: CheckKind.BaseType, expected: ["Ucs2String", "UsvString"]} satisfies BaseTypeCheck);
+    }
+    return visitor.fromString(input);
+  }
+}
+
+export const SEARCH_PARAMS_VALUE_READER: SearchParamsValueReader = new SearchParamsValueReader();

--- a/packages/kryo-search-params/src/lib/search-params-value-writer.mts
+++ b/packages/kryo-search-params/src/lib/search-params-value-writer.mts
@@ -1,0 +1,97 @@
+import {Writer} from "kryo";
+import {JsonWriter} from "kryo-json/json-writer";
+import {JsonValue} from "kryo-json/json-value";
+import {JsonValueWriter} from "kryo-json/json-value-writer";
+
+export class SearchParamsValueWriter implements Writer<URLSearchParams | string> {
+  #isRoot: boolean;
+
+  public constructor(isRoot: boolean = true) {
+    this.#isRoot = isRoot;
+  }
+
+  writeAny(value: unknown): string {
+    return JSON.stringify(value);
+  }
+
+  writeBoolean(value: boolean): "true" | "false" {
+    return value ? "true" : "false";
+  }
+
+  writeBytes(value: Uint8Array): string {
+    const result: string[] = new Array(value.length);
+    const len: number = value.length;
+    for (let i: number = 0; i < len; i++) {
+      result[i] = (value[i] < 16 ? "0" : "") + value[i].toString(16);
+    }
+    return result.join("");
+  }
+
+  writeDate(value: Date): string {
+    return value.toISOString();
+  }
+
+  writeFloat64(value: number): string {
+    if (isNaN(value)) {
+      return "NaN";
+    } else if (value === Infinity) {
+      return "+Infinity";
+    } else if (value === -Infinity) {
+      return "-Infinity";
+    }
+    return value.toString(10);
+  }
+
+  writeList(size: number, handler: (index: number, itemWriter: Writer<string>) => string): string {
+    const jsonWriter: JsonWriter = new JsonWriter();
+    return jsonWriter.writeList(size, handler);
+  }
+
+  writeNull(): "" {
+    return "";
+  }
+
+  writeMap(
+    size: number,
+    keyHandler: <KW>(index: number, mapKeyWriter: Writer<KW>) => KW,
+    valueHandler: <VW>(index: number, mapValueWriter: Writer<VW>) => VW,
+  ): URLSearchParams | string {
+    if (!this.#isRoot) {
+      const jsonWriter: JsonWriter = new JsonWriter();
+      return jsonWriter.writeMap(size, keyHandler, valueHandler);
+    }
+
+    const result: URLSearchParams = new URLSearchParams();
+    for (let index: number = 0; index < size; index++) {
+      // TODO: Use a specialized writer that only accepts strings and numbers (KeyMustBeAStringError)
+      // Let users build custom serializers if they want
+      const jsonWriter: JsonValueWriter = new JsonValueWriter();
+      const key: JsonValue = keyHandler(index, jsonWriter);
+      result.set(JSON.stringify(key), valueHandler(index, NESTED_SEARCH_PARAMS_VALUE_WRITER as Writer<string>));
+    }
+    return result;
+  }
+
+  writeRecord<K extends string>(
+    keys: Iterable<K>,
+    handler: (key: K, fieldWriter: Writer<string>) => string,
+  ): URLSearchParams | string {
+    if (!this.#isRoot) {
+      const jsonWriter: JsonWriter = new JsonWriter();
+      return jsonWriter.writeRecord(keys, handler);
+    }
+
+    const result: URLSearchParams = new URLSearchParams();
+    for (const key of keys) {
+      result.set(key, handler(key, NESTED_SEARCH_PARAMS_VALUE_WRITER as Writer<string>));
+    }
+    return result;
+  }
+
+  writeString(value: string): string {
+    return value;
+  }
+}
+
+export const SEARCH_PARAMS_VALUE_WRITER: SearchParamsValueWriter = new SearchParamsValueWriter();
+const NESTED_SEARCH_PARAMS_VALUE_WRITER: SearchParamsValueWriter = new SearchParamsValueWriter(false);

--- a/packages/kryo-search-params/src/lib/search-params-writer.mts
+++ b/packages/kryo-search-params/src/lib/search-params-writer.mts
@@ -1,0 +1,62 @@
+import {Writer} from "kryo";
+
+import {SearchParamsValueWriter} from "./search-params-value-writer.mjs";
+
+export class SearchParamsWriter implements Writer<string> {
+  readonly #valueWriter: SearchParamsValueWriter;
+  readonly #primitiveWrapper: string;
+
+  constructor(primitiveWrapper: string = "_") {
+    this.#primitiveWrapper = primitiveWrapper;
+    this.#valueWriter = new SearchParamsValueWriter();
+  }
+
+  writeAny(value: number): string {
+    return new URLSearchParams({[this.#primitiveWrapper]: this.#valueWriter.writeAny(value)}).toString();
+  }
+
+  writeBoolean(value: boolean): string {
+    return new URLSearchParams({[this.#primitiveWrapper]: this.#valueWriter.writeBoolean(value)}).toString();
+  }
+
+  writeBytes(value: Uint8Array): string {
+    return new URLSearchParams({[this.#primitiveWrapper]: this.#valueWriter.writeBytes(value)}).toString();
+  }
+
+  writeDate(value: Date): string {
+    return new URLSearchParams({[this.#primitiveWrapper]: this.#valueWriter.writeDate(value)}).toString();
+  }
+
+  writeRecord<K extends string>(
+    keys: Iterable<K>,
+    handler: (key: K, fieldWriter: Writer<any>) => any,
+  ): string {
+    return this.#valueWriter.writeRecord(keys, handler).toString();
+  }
+
+  writeFloat64(value: number): string {
+    return new URLSearchParams({[this.#primitiveWrapper]: this.#valueWriter.writeFloat64(value)}).toString();
+  }
+
+  writeList(size: number, handler: (index: number, itemWriter: Writer<any>) => any): string {
+    return new URLSearchParams({[this.#primitiveWrapper]: this.#valueWriter.writeList(size, handler)}).toString();
+  }
+
+  writeMap(
+    size: number,
+    keyHandler: <KW>(index: number, mapKeyWriter: Writer<KW>) => KW,
+    valueHandler: <VW>(index: number, mapValueWriter: Writer<VW>) => VW,
+  ): any {
+    return this.#valueWriter.writeMap(size, keyHandler, valueHandler).toString();
+  }
+
+  writeNull(): string {
+    return new URLSearchParams({[this.#primitiveWrapper]: this.#valueWriter.writeNull()}).toString();
+  }
+
+  writeString(value: string): string {
+    return new URLSearchParams({[this.#primitiveWrapper]: this.#valueWriter.writeString(value)}).toString();
+  }
+}
+
+export const SEARCH_PARAMS_WRITER: SearchParamsWriter = new SearchParamsWriter();

--- a/packages/kryo-search-params/src/lib/tsconfig.json
+++ b/packages/kryo-search-params/src/lib/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "extends": "../../../../tsconfig.json",
+  "compilerOptions": {
+    "composite": true,
+    "rootDir": ".",
+    "outDir": "../../lib"
+  },
+  "include": [
+    "./**/*.mts"
+  ],
+  "exclude": [],
+  "references": [
+    {
+      "path": "../../../kryo/src/lib"
+    },
+    {
+      "path": "../../../kryo-json/src/lib"
+    }
+  ]
+}

--- a/packages/kryo-search-params/src/test/tsconfig.json
+++ b/packages/kryo-search-params/src/test/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "../../test"
+  },
+  "include": [
+    "**/*.mts"
+  ],
+  "exclude": [],
+  "references": [
+    {
+      "path": "../lib"
+    },
+    {
+      "path": "../../../kryo-testing/src/lib"
+    }
+  ]
+}

--- a/packages/kryo-search-params/src/test/types/any.spec.mts
+++ b/packages/kryo-search-params/src/test/types/any.spec.mts
@@ -1,0 +1,36 @@
+import {assert as chaiAssert} from "chai";
+import {readOrThrow} from "kryo";
+import {$Any, AnyType} from "kryo/any";
+import {RecordIoType, RecordType} from "kryo/record";
+import {SEARCH_PARAMS_READER} from "../../lib/search-params-reader.mjs";
+import {SEARCH_PARAMS_VALUE_READER} from "../../lib/search-params-value-reader.mjs";
+
+describe("kryo-search-params | Any", function () {
+  describe("with JsonReader", function () {
+    it("should read the expected top-level values", function () {
+      const $Any: AnyType = new AnyType();
+      chaiAssert.deepEqual(readOrThrow($Any, SEARCH_PARAMS_READER, "0"), "0");
+      chaiAssert.deepEqual(readOrThrow($Any, SEARCH_PARAMS_READER, "foo=bar"), "foo=bar");
+    });
+    it("should read the expected nested values", function () {
+      const $Any: AnyType = new AnyType();
+
+      interface FooBarQuz {
+        foo: unknown;
+      }
+
+      const $FooBarQuz: RecordIoType<FooBarQuz> = new RecordType({
+        properties: {foo: {type: $Any}},
+      });
+
+      chaiAssert.deepEqual(readOrThrow($FooBarQuz, SEARCH_PARAMS_READER, "foo=\{\"bar\":\"quz\"}"), {foo: "{\"bar\":\"quz\"}"});
+    });
+  });
+
+  describe("with JsonValueReader", function () {
+    it("should read the expected values", function () {
+      chaiAssert.deepEqual(readOrThrow($Any, SEARCH_PARAMS_VALUE_READER, "0"), "0");
+      chaiAssert.deepEqual(readOrThrow($Any, SEARCH_PARAMS_VALUE_READER, "{\"foo\": \"bar\"}"), "{\"foo\": \"bar\"}");
+    });
+  });
+});

--- a/packages/kryo-search-params/src/test/types/array.spec.mts
+++ b/packages/kryo-search-params/src/test/types/array.spec.mts
@@ -1,0 +1,219 @@
+import { ArrayIoType, ArrayType } from "kryo/array";
+import { $Boolean } from "kryo/boolean";
+import { $Uint8, IntegerType } from "kryo/integer";
+import { registerErrMochaTests, registerMochaSuites, TestItem } from "kryo-testing";
+
+import {SEARCH_PARAMS_READER} from "../../lib/search-params-reader.mjs";
+import {SEARCH_PARAMS_WRITER} from "../../lib/search-params-writer.mjs";
+
+describe("kryo-search-params | Array", function () {
+  describe("Main", function () {
+    const $IntArray: ArrayIoType<number> = new ArrayType({
+      itemType: new IntegerType(),
+      maxLength: 2,
+    });
+
+    const items: TestItem[] = [
+      {
+        value: [],
+        io: [
+          {writer: SEARCH_PARAMS_WRITER, reader: SEARCH_PARAMS_READER, raw: "_=%5B%5D"},
+        ],
+      },
+      {
+        value: [1],
+        io: [
+          {writer: SEARCH_PARAMS_WRITER, reader: SEARCH_PARAMS_READER, raw: "_=%5B1%5D"},
+          {reader: SEARCH_PARAMS_READER, raw: "_=[1]"},
+        ],
+      },
+      {
+        value: [2, 3],
+        io: [
+          {writer: SEARCH_PARAMS_WRITER, reader: SEARCH_PARAMS_READER, raw: "_=%5B2%2C3%5D"},
+          {reader: SEARCH_PARAMS_READER, raw: "_=[2,3]"},
+        ],
+      },
+    ];
+
+    registerMochaSuites($IntArray, items);
+
+    describe("Reader", function () {
+      const invalids: string[] = [
+        "_[0]=1",
+        "_[0]=1&_[1]=3",
+        "[4,5,6]",
+        "[0.5]",
+        "[null]",
+        "[undefined]",
+        "[]",
+        "true",
+        "false",
+        "",
+        "0",
+        "1",
+        "0.5",
+        "0.0001",
+        "2.220446049250313e-16",
+        "9007199254740991",
+        "-9007199254740991",
+        "\"\"",
+        "\"0\"",
+        "\"1\"",
+        "\"null\"",
+        "\"true\"",
+        "\"false\"",
+        "\"undefined\"",
+        "\"NaN\"",
+        "\"Infinity\"",
+        "\"-Infinity\"",
+        "\"foo\"",
+        "[]",
+        "{}",
+        "\"1970-01-01T00:00:00.000Z\"",
+      ];
+      registerErrMochaTests(SEARCH_PARAMS_READER, $IntArray, invalids);
+    });
+  });
+
+  describe("Min/Max length", function () {
+    const $IntArray: ArrayIoType<number> = new ArrayType({
+      itemType: $Uint8,
+      minLength: 2,
+      maxLength: 4,
+    });
+
+    const items: TestItem[] = [
+      {
+        value: [0, 1],
+        io: [
+          {writer: SEARCH_PARAMS_WRITER, reader: SEARCH_PARAMS_READER, raw: "_=%5B0%2C1%5D"},
+        ],
+      },
+      {
+        value: [0, 1, 2],
+        io: [
+          {writer: SEARCH_PARAMS_WRITER, reader: SEARCH_PARAMS_READER, raw: "_=%5B0%2C1%2C2%5D"},
+        ],
+      },
+      {
+        value: [0, 1, 2, 3],
+        io: [
+          {writer: SEARCH_PARAMS_WRITER, reader: SEARCH_PARAMS_READER, raw: "_=%5B0%2C1%2C2%2C3%5D"},
+        ],
+      },
+    ];
+
+    registerMochaSuites($IntArray, items);
+
+    describe("Reader", function () {
+      const invalids: string[] = [
+        "[0.5]",
+        "[null]",
+        "[undefined]",
+        "[]",
+        "[0]",
+        "[0,1,2,3,4]",
+        "true",
+        "false",
+        "",
+        "0",
+        "1",
+        "0.5",
+        "0.0001",
+        "2.220446049250313e-16",
+        "9007199254740991",
+        "-9007199254740991",
+        "\"\"",
+        "\"0\"",
+        "\"1\"",
+        "\"null\"",
+        "\"true\"",
+        "\"false\"",
+        "\"undefined\"",
+        "\"NaN\"",
+        "\"Infinity\"",
+        "\"-Infinity\"",
+        "\"foo\"",
+        "[]",
+        "{}",
+        "\"1970-01-01T00:00:00.000Z\"",
+      ];
+      registerErrMochaTests(SEARCH_PARAMS_READER, $IntArray, invalids);
+    });
+  });
+
+  describe("Nested array", function () {
+    const $NestedBooleanArray: ArrayIoType<boolean[]> = new ArrayType({
+      itemType: new ArrayType({
+        itemType: $Boolean,
+        maxLength: Infinity,
+      }),
+      maxLength: Infinity,
+    });
+
+    const items: TestItem[] = [
+      {
+        value: [],
+        io: [
+          {writer: SEARCH_PARAMS_WRITER, reader: SEARCH_PARAMS_READER, raw: "_=%5B%5D"},
+        ],
+      },
+      {
+        value: [[]],
+        io: [
+          {writer: SEARCH_PARAMS_WRITER, raw: "_=%5B%5B%5D%5D"},
+        ],
+      },
+      {
+        value: [[true], [false, true]],
+        io: [
+          {
+            writer: SEARCH_PARAMS_WRITER,
+            reader: SEARCH_PARAMS_READER,
+            raw: "_=%5B%5Btrue%5D%2C%5Bfalse%2Ctrue%5D%5D",
+          },
+        ],
+      },
+    ];
+
+    registerMochaSuites($NestedBooleanArray, items);
+
+    describe("Reader", function () {
+      const invalids: string[] = [
+        "[0.5]",
+        "[null]",
+        "[undefined]",
+        "[]",
+        "[[[]]]",
+        "[0]",
+        "[0,1,2,3,4]",
+        "true",
+        "false",
+        "",
+        "0",
+        "1",
+        "0.5",
+        "0.0001",
+        "2.220446049250313e-16",
+        "9007199254740991",
+        "-9007199254740991",
+        "\"\"",
+        "\"0\"",
+        "\"1\"",
+        "\"null\"",
+        "\"true\"",
+        "\"false\"",
+        "\"undefined\"",
+        "\"NaN\"",
+        "\"Infinity\"",
+        "\"-Infinity\"",
+        "\"foo\"",
+        "[]",
+        "{}",
+        "\"1970-01-01T00:00:00.000Z\"",
+      ];
+      registerErrMochaTests(SEARCH_PARAMS_READER, $NestedBooleanArray, invalids);
+    });
+  });
+});

--- a/packages/kryo-search-params/src/test/types/boolean.spec.mts
+++ b/packages/kryo-search-params/src/test/types/boolean.spec.mts
@@ -1,0 +1,25 @@
+import { BooleanType } from "kryo/boolean";
+import { registerErrMochaTests, registerMochaSuites, TestItem } from "kryo-testing";
+
+import {SEARCH_PARAMS_READER} from "../../lib/search-params-reader.mjs";
+import {SEARCH_PARAMS_WRITER} from "../../lib/search-params-writer.mjs";
+
+describe("kryo-search-params | Boolean", function () {
+  const type: BooleanType = new BooleanType();
+
+  const items: TestItem[] = [
+    {name: "true", value: true, io: [{writer: SEARCH_PARAMS_WRITER, reader: SEARCH_PARAMS_READER, raw: "_=true"}]},
+    {name: "false", value: false, io: [{writer: SEARCH_PARAMS_WRITER, reader: SEARCH_PARAMS_READER, raw: "_=false"}]},
+  ];
+
+  registerMochaSuites(type, items);
+
+  describe("Reader", function () {
+    const invalids: string[] = [
+      "1",
+      "\"on\"",
+      "\"true\"",
+    ];
+    registerErrMochaTests(SEARCH_PARAMS_READER, type, invalids);
+  });
+});

--- a/packages/kryo-search-params/src/test/types/bytes.spec.mts
+++ b/packages/kryo-search-params/src/test/types/bytes.spec.mts
@@ -1,0 +1,59 @@
+import { BytesType } from "kryo/bytes";
+import { registerErrMochaTests, registerMochaSuites, TestItem } from "kryo-testing";
+
+import {SEARCH_PARAMS_READER} from "../../lib/search-params-reader.mjs";
+import {SEARCH_PARAMS_WRITER} from "../../lib/search-params-writer.mjs";
+
+describe("kryo-search-params | Bytes", function () {
+  const shortBuffer: BytesType = new BytesType({
+    maxLength: 2,
+  });
+
+  const items: TestItem[] = [
+    {
+      name: "Uint8Array.from([])",
+      value: Uint8Array.from([]),
+      io: [
+        {writer: SEARCH_PARAMS_WRITER, reader: SEARCH_PARAMS_READER, raw: "_="},
+      ],
+    },
+    {
+      name: "Uint8Array.from([1])",
+      value: Uint8Array.from([1]),
+      io: [
+        {writer: SEARCH_PARAMS_WRITER, reader: SEARCH_PARAMS_READER, raw: "_=01"},
+      ],
+    },
+    {
+      name: "Uint8Array.from([2, 3])",
+      value: Uint8Array.from([2, 3]),
+      io: [
+        {writer: SEARCH_PARAMS_WRITER, reader: SEARCH_PARAMS_READER, raw: "_=0203"},
+      ],
+    },
+  ];
+
+  registerMochaSuites(shortBuffer, items);
+
+  describe("Reader", function () {
+    const invalids: string[] = [
+      "\"040506\"",
+      "[7]",
+      "[0.5]",
+      "[null]",
+      "[]",
+      "[0]",
+      "[0, 0]",
+      "\"1970-01-01T00:00:00.000Z\"",
+      "0",
+      "1",
+      "",
+      "\"0\"",
+      "\"true\"",
+      "\"false\"",
+      "null",
+      "{}",
+    ];
+    registerErrMochaTests(SEARCH_PARAMS_READER, shortBuffer, invalids);
+  });
+});

--- a/packages/kryo-search-params/src/test/types/custom.spec.mts
+++ b/packages/kryo-search-params/src/test/types/custom.spec.mts
@@ -1,0 +1,164 @@
+import {CheckId, KryoContext, Reader, Result, writeError,Writer} from "kryo";
+import {CheckKind} from "kryo/checks/check-kind";
+import {CustomType} from "kryo/custom";
+import {readVisitor} from "kryo/readers/read-visitor";
+import {registerErrMochaTests, registerMochaSuites, TestItem} from "kryo-testing";
+
+import {SEARCH_PARAMS_WRITER} from "../../lib/search-params-writer.mjs";
+import {SEARCH_PARAMS_READER} from "../../lib/search-params-reader.mjs";
+
+describe("kryo-search-params | Custom", function () {
+  describe("ComplexNumber", function () {
+    class ComplexParseError extends Error {
+      public input: string;
+
+      public constructor(input: string) {
+        super(`invalid input format for \`Complex\`: ${JSON.stringify(input)}`);
+        this.input = input;
+      }
+    }
+
+    /**
+     * Represents a complex number.
+     * It only deals with complex number with small unsigned integer cartesian components for
+     * simplicity.
+     */
+    class Complex {
+      readonly real: number;
+      readonly imaginary: number;
+
+      constructor(real: number, imaginary: number) {
+        this.real = real;
+        this.imaginary = imaginary;
+        Object.freeze(this);
+      }
+
+      static fromString(input: string): Complex {
+        const realMatch: RegExpExecArray | null = /^(\d+)(?:\s*\+\s*\d+j)?$/.exec(input);
+        const imaginaryMatch: RegExpExecArray | null = /^(?:\d+\s*\+\s*)?(\d+)j$/.exec(input);
+        if (realMatch === null && imaginaryMatch === null) {
+          throw new ComplexParseError(input);
+        }
+        const real: number = realMatch !== null ? parseInt(realMatch[1], 10) : 0;
+        const imaginary: number = imaginaryMatch !== null ? parseInt(imaginaryMatch[1], 10) : 0;
+        return new Complex(real, imaginary);
+      }
+
+      toString(): string {
+        const parts: string[] = [];
+        if (this.real !== 0) {
+          parts.push(this.real.toString(10));
+        }
+        if (this.imaginary !== 0) {
+          parts.push(`${this.imaginary.toString(10)}j`);
+        }
+        // tslint:disable-next-line:strict-boolean-expressions
+        return parts.join(" + ") || "0";
+      }
+    }
+
+    const $Complex: CustomType<Complex> = new CustomType({
+      read<R>(cx: KryoContext, reader: Reader<R>, raw: R): Result<Complex, CheckId> {
+        return reader.readString(cx, raw, readVisitor({
+          fromString: (input: string): Result<Complex, CheckId> => {
+            try {
+              const value = Complex.fromString(input);
+              return {ok: true, value};
+            } catch (e) {
+              if (e instanceof ComplexParseError) {
+                return writeError(cx, {check: CheckKind.BaseType, expected: ["Object"]});
+              } else {
+                throw e;
+              }
+            }
+          },
+          fromFloat64: (input: number): Result<Complex, CheckId> => {
+            const value = new Complex(input, 0);
+            return {ok: true, value};
+          },
+        }));
+      },
+      write<W>(writer: Writer<W>, value: Complex): W {
+        return writer.writeString(value.toString());
+      },
+      test(cx: KryoContext, value: unknown): Result<Complex, CheckId> {
+        if (!(value instanceof Complex)) {
+          return writeError(cx, {check: CheckKind.BaseType, expected: ["Object"]});
+        }
+        return {ok: true, value};
+      },
+      equals(value1: Complex, value2: Complex): boolean {
+        return value1.real === value2.real && value1.imaginary === value2.imaginary;
+      },
+      clone(value: Complex): Complex {
+        return new Complex(value.real, value.imaginary);
+      },
+    });
+
+    const items: TestItem[] = [
+      {
+        name: "Complex {real: 0, imaginary: 0}",
+        value: new Complex(0, 0),
+        io: [
+          {writer: SEARCH_PARAMS_WRITER, reader: SEARCH_PARAMS_READER, raw: "_=0"},
+        ],
+      },
+      {
+        name: "Complex {real: 1, imaginary: 0}",
+        value: new Complex(1, 0),
+        io: [
+          {writer: SEARCH_PARAMS_WRITER, reader: SEARCH_PARAMS_READER, raw: "_=1"},
+        ],
+      },
+      {
+        name: "Complex {real: 0, imaginary: 2}",
+        value: new Complex(0, 2),
+        io: [
+          {writer: SEARCH_PARAMS_WRITER, reader: SEARCH_PARAMS_READER, raw: "_=2j"},
+        ],
+      },
+      {
+        name: "Complex {real: 3, imaginary: 4}",
+        value: new Complex(3, 4),
+        io: [
+          {writer: SEARCH_PARAMS_WRITER, reader: SEARCH_PARAMS_READER, raw: "_=3+%2B+4j"},
+          {reader: SEARCH_PARAMS_READER, raw: "_=3 %2B 4j"},
+        ],
+      },
+    ];
+
+    registerMochaSuites($Complex, items);
+
+    describe("Reader", function () {
+      const invalids: string[] = [
+        "_=3 + 4j",
+        "null",
+        "true",
+        "false",
+        "",
+        "0",
+        "1",
+        "0.5",
+        "0.0001",
+        "2.220446049250313e-16",
+        "9007199254740991",
+        "-9007199254740991",
+        "\"\"",
+        "\"0\"",
+        "\"1\"",
+        "\"null\"",
+        "\"true\"",
+        "\"false\"",
+        "\"undefined\"",
+        "\"NaN\"",
+        "\"Infinity\"",
+        "\"-Infinity\"",
+        "\"foo\"",
+        "[]",
+        "{}",
+        "\"1970-01-01T00:00:00.000Z\"",
+      ];
+      registerErrMochaTests(SEARCH_PARAMS_READER, $Complex, invalids);
+    });
+  });
+});

--- a/packages/kryo-search-params/src/test/types/date.spec.mts
+++ b/packages/kryo-search-params/src/test/types/date.spec.mts
@@ -1,0 +1,66 @@
+import { DateType } from "kryo/date";
+import { registerErrMochaTests, registerMochaSuites, TestItem } from "kryo-testing";
+
+import {SEARCH_PARAMS_READER} from "../../lib/search-params-reader.mjs";
+import {SEARCH_PARAMS_WRITER} from "../../lib/search-params-writer.mjs";
+
+describe("kryo-search-params | Date", function () {
+  const type: DateType = new DateType();
+
+  const items: TestItem[] = [
+    {
+      name: "new Date(0)",
+      value: new Date(0),
+      io: [
+        {writer: SEARCH_PARAMS_WRITER, reader: SEARCH_PARAMS_READER, raw: "_=1970-01-01T00%3A00%3A00.000Z"},
+        // {reader: SEARCH_PARAMS_READER, raw: "_=0"},
+      ],
+    },
+    {
+      name: "new Date(1)",
+      value: new Date(1),
+      io: [
+        {writer: SEARCH_PARAMS_WRITER, reader: SEARCH_PARAMS_READER, raw: "_=1970-01-01T00%3A00%3A00.001Z"},
+        // {reader: SEARCH_PARAMS_READER, raw: "_=1"},
+      ],
+    },
+    {
+      name: "new Date(\"1247-05-18T19:40:08.418Z\")",
+      value: new Date("1247-05-18T19:40:08.418Z"),
+      io: [
+        {writer: SEARCH_PARAMS_WRITER, reader: SEARCH_PARAMS_READER, raw: "_=1247-05-18T19%3A40%3A08.418Z"},
+      ],
+    },
+    {
+      name: "new Date(Number.EPSILON)",
+      value: new Date(Number.EPSILON),
+      io: [
+        {writer: SEARCH_PARAMS_WRITER, reader: SEARCH_PARAMS_READER, raw: "_=1970-01-01T00%3A00%3A00.000Z"},
+      ],
+    },
+    {
+      name: "new Date(Math.PI)",
+      value: new Date(Math.PI),
+      io: [
+        {writer: SEARCH_PARAMS_WRITER, reader: SEARCH_PARAMS_READER, raw: "_=1970-01-01T00%3A00%3A00.003Z"},
+      ],
+    },
+  ];
+
+  registerMochaSuites(type, items);
+
+  describe("Reader", function () {
+    const invalids: string[] = [
+      "null",
+      "\"\"",
+      "\"0\"",
+      "\"true\"",
+      "\"false\"",
+      "true",
+      "false",
+      "[]",
+      "{}",
+    ];
+    registerErrMochaTests(SEARCH_PARAMS_READER, type, invalids);
+  });
+});

--- a/packages/kryo-search-params/src/test/types/float64.spec.mts
+++ b/packages/kryo-search-params/src/test/types/float64.spec.mts
@@ -1,0 +1,193 @@
+import { Float64Type } from "kryo/float64";
+import { registerErrMochaTests, registerMochaSuites, TestItem } from "kryo-testing";
+
+import {SEARCH_PARAMS_READER} from "../../lib/search-params-reader.mjs";
+import {SEARCH_PARAMS_WRITER} from "../../lib/search-params-writer.mjs";
+
+describe("kryo-search-params | Float64", function () {
+  const $Float64: Float64Type = new Float64Type();
+
+  const items: TestItem[] = [
+    {
+      name: "0",
+      value: 0,
+      io: [
+        {writer: SEARCH_PARAMS_WRITER, reader: SEARCH_PARAMS_READER, raw: "_=0"},
+      ],
+    },
+    {
+      name: "1",
+      value: 1,
+      io: [
+        {writer: SEARCH_PARAMS_WRITER, reader: SEARCH_PARAMS_READER, raw: "_=1"},
+      ],
+    },
+    {
+      name: "-1",
+      value: -1,
+      io: [
+        {writer: SEARCH_PARAMS_WRITER, reader: SEARCH_PARAMS_READER, raw: "_=-1"},
+      ],
+    },
+    {
+      name: "1e3",
+      value: 1e3,
+      io: [
+        {writer: SEARCH_PARAMS_WRITER, reader: SEARCH_PARAMS_READER, raw: "_=1000"},
+      ],
+    },
+    {
+      name: "-1e3",
+      value: -1e3,
+      io: [
+        {writer: SEARCH_PARAMS_WRITER, reader: SEARCH_PARAMS_READER, raw: "_=-1000"},
+      ],
+    },
+    {
+      name: "Number.MAX_SAFE_INTEGER",
+      value: Number.MAX_SAFE_INTEGER,
+      io: [
+        {writer: SEARCH_PARAMS_WRITER, reader: SEARCH_PARAMS_READER, raw: "_=9007199254740991"},
+      ],
+    },
+    {
+      name: "Number.MIN_SAFE_INTEGER",
+      value: Number.MIN_SAFE_INTEGER,
+      io: [
+        {writer: SEARCH_PARAMS_WRITER, reader: SEARCH_PARAMS_READER, raw: "_=-9007199254740991"},
+      ],
+    },
+    {
+      name: "Number.MAX_VALUE",
+      value: Number.MAX_VALUE,
+      io: [
+        {writer: SEARCH_PARAMS_WRITER, reader: SEARCH_PARAMS_READER, raw: "_=1.7976931348623157e%2B308"},
+      ],
+    },
+    {
+      name: "Number.MIN_VALUE",
+      value: Number.MIN_VALUE,
+      io: [
+        {writer: SEARCH_PARAMS_WRITER, reader: SEARCH_PARAMS_READER, raw: "_=5e-324"},
+      ],
+    },
+    {
+      name: "0.5",
+      value: 0.5,
+      io: [
+        {writer: SEARCH_PARAMS_WRITER, reader: SEARCH_PARAMS_READER, raw: "_=0.5"},
+      ],
+    },
+    {
+      name: "0.0001",
+      value: 0.0001,
+      io: [
+        {writer: SEARCH_PARAMS_WRITER, reader: SEARCH_PARAMS_READER, raw: "_=0.0001"},
+      ],
+    },
+    {
+      name: "Number.EPSILON",
+      value: Number.EPSILON,
+      io: [
+        {writer: SEARCH_PARAMS_WRITER, reader: SEARCH_PARAMS_READER, raw: "_=2.220446049250313e-16"},
+      ],
+    },
+  ];
+
+  registerMochaSuites($Float64, items);
+
+  describe("Reader", function () {
+    const invalids: string[] = [
+      "null",
+      "true",
+      "false",
+      "",
+      "\"\"",
+      "\"0\"",
+      "\"null\"",
+      "\"true\"",
+      "\"false\"",
+      "\"NaN\"",
+      "\"Infinity\"",
+      "\"-Infinity\"",
+      "[]",
+      "{}",
+      "\"1970-01-01T00:00:00.000Z\"",
+    ];
+    registerErrMochaTests(SEARCH_PARAMS_READER, $Float64, invalids);
+  });
+
+  describe("NaN support", function () {
+    const $Float64WithNan: Float64Type = new Float64Type({allowNaN: true});
+    const items: TestItem[] = [
+      {
+        value: 0,
+        io: [
+          {writer: SEARCH_PARAMS_WRITER, reader: SEARCH_PARAMS_READER, raw: "_=0"},
+        ],
+      },
+      {
+        value: 1,
+        io: [
+          {writer: SEARCH_PARAMS_WRITER, reader: SEARCH_PARAMS_READER, raw: "_=1"},
+        ],
+      },
+      {
+        value: NaN,
+        io: [
+          {writer: SEARCH_PARAMS_WRITER, reader: SEARCH_PARAMS_READER, raw: "_=NaN"},
+        ],
+      },
+    ];
+
+    registerMochaSuites($Float64WithNan, items);
+
+    describe("Reader", function () {
+      const invalids: string[] = [
+        "_=Infinity",
+        "_=-Infinity",
+      ];
+      registerErrMochaTests(SEARCH_PARAMS_READER, $Float64WithNan, invalids);
+    });
+  });
+
+  describe("Infinity support", function () {
+    const $Float64WithInfinity: Float64Type = new Float64Type({allowInfinity: true});
+    const items: TestItem[] = [
+      {
+        value: 0,
+        io: [
+          {writer: SEARCH_PARAMS_WRITER, reader: SEARCH_PARAMS_READER, raw: "_=0"},
+        ],
+      },
+      {
+        value: 1,
+        io: [
+          {writer: SEARCH_PARAMS_WRITER, reader: SEARCH_PARAMS_READER, raw: "_=1"},
+        ],
+      },
+      {
+        value: Infinity,
+        io: [
+          {writer: SEARCH_PARAMS_WRITER, reader: SEARCH_PARAMS_READER, raw: "_=%2BInfinity"},
+          {reader: SEARCH_PARAMS_READER, raw: "_=Infinity"},
+        ],
+      },
+      {
+        value: -Infinity,
+        io: [
+          {writer: SEARCH_PARAMS_WRITER, reader: SEARCH_PARAMS_READER, raw: "_=-Infinity"},
+        ],
+      },
+    ];
+
+    registerMochaSuites($Float64WithInfinity, items);
+
+    describe("Reader", function () {
+      const invalids: string[] = [
+        "_=NaN",
+      ];
+      registerErrMochaTests(SEARCH_PARAMS_READER, $Float64WithInfinity, invalids);
+    });
+  });
+});

--- a/packages/kryo-search-params/src/test/types/integer.spec.mts
+++ b/packages/kryo-search-params/src/test/types/integer.spec.mts
@@ -1,0 +1,119 @@
+import { IntegerType } from "kryo/integer";
+import { registerErrMochaTests, registerMochaSuites, TestItem } from "kryo-testing";
+
+import {SEARCH_PARAMS_READER} from "../../lib/search-params-reader.mjs";
+import {SEARCH_PARAMS_WRITER} from "../../lib/search-params-writer.mjs";
+
+describe("kryo-search-params | Integer", function () {
+  describe("Main", function () {
+    const $Integer: IntegerType = new IntegerType();
+
+    const items: TestItem[] = [
+      {
+        name: "0",
+        value: 0,
+        io: [
+          {writer: SEARCH_PARAMS_WRITER, reader: SEARCH_PARAMS_READER, raw: "_=0"},
+        ],
+      },
+      {
+        name: "1",
+        value: 1,
+        io: [
+          {writer: SEARCH_PARAMS_WRITER, reader: SEARCH_PARAMS_READER, raw: "_=1"},
+        ],
+      },
+      {
+        name: "-1",
+        value: -1,
+        io: [
+          {writer: SEARCH_PARAMS_WRITER, reader: SEARCH_PARAMS_READER, raw: "_=-1"},
+        ],
+      },
+      {
+        name: "2",
+        value: 2,
+        io: [
+          {writer: SEARCH_PARAMS_WRITER, reader: SEARCH_PARAMS_READER, raw: "_=2"},
+        ],
+      },
+      {
+        name: "1e3",
+        value: 1e3,
+        io: [
+          {writer: SEARCH_PARAMS_WRITER, reader: SEARCH_PARAMS_READER, raw: "_=1000"},
+        ],
+      },
+      {
+        name: "-1e3",
+        value: -1e3,
+        io: [
+          {writer: SEARCH_PARAMS_WRITER, reader: SEARCH_PARAMS_READER, raw: "_=-1000"},
+        ],
+      },
+      {
+        name: "Number.MAX_SAFE_INTEGER",
+        value: Number.MAX_SAFE_INTEGER,
+        io: [
+          {writer: SEARCH_PARAMS_WRITER, reader: SEARCH_PARAMS_READER, raw: "_=9007199254740991"},
+        ],
+      },
+      {
+        name: "Number.MAX_SAFE_INTEGER - 1",
+        value: Number.MAX_SAFE_INTEGER - 1,
+        io: [
+          {writer: SEARCH_PARAMS_WRITER, reader: SEARCH_PARAMS_READER, raw: "_=9007199254740990"},
+        ],
+      },
+      {
+        name: "Number.MIN_SAFE_INTEGER",
+        value: Number.MIN_SAFE_INTEGER,
+        io: [
+          {writer: SEARCH_PARAMS_WRITER, reader: SEARCH_PARAMS_READER, raw: "_=-9007199254740991"},
+        ],
+      },
+      {
+        name: "Number.MIN_SAFE_INTEGER - 1",
+        value: Number.MIN_SAFE_INTEGER - 1,
+        io: [
+          {writer: SEARCH_PARAMS_WRITER, reader: SEARCH_PARAMS_READER, raw: "_=-9007199254740992"},
+        ],
+      },
+      {
+        name: "Number.MIN_SAFE_INTEGER + 1",
+        value: Number.MIN_SAFE_INTEGER + 1,
+        io: [
+          {writer: SEARCH_PARAMS_WRITER, reader: SEARCH_PARAMS_READER, raw: "_=-9007199254740990"},
+        ],
+      },
+    ];
+
+    registerMochaSuites($Integer, items);
+
+    describe("Reader", function () {
+      const invalids: string[] = [
+        "null",
+        "true",
+        "false",
+        "",
+        "0.5",
+        "0.0001",
+        "2.220446049250313e-16",
+        "9007199254740992", // Number.MAX_SAFE_INTEGER + 1
+        "-9007199254740993", // Number.MIN_SAFE_INTEGER - 2
+        "\"\"",
+        "\"0\"",
+        "\"null\"",
+        "\"true\"",
+        "\"false\"",
+        "\"NaN\"",
+        "\"Infinity\"",
+        "\"-Infinity\"",
+        "[]",
+        "{}",
+        "\"1970-01-01T00:00:00.000Z\"",
+      ];
+      registerErrMochaTests(SEARCH_PARAMS_READER, $Integer, invalids);
+    });
+  });
+});

--- a/packages/kryo-search-params/src/test/types/literal-union.mts
+++ b/packages/kryo-search-params/src/test/types/literal-union.mts
@@ -1,0 +1,75 @@
+import { LiteralUnionType } from "kryo/literal-union";
+import { Ucs2StringType } from "kryo/ucs2-string";
+import { registerErrMochaTests, registerMochaSuites, TestItem } from "kryo-testing";
+
+import {SEARCH_PARAMS_READER} from "../../lib/search-params-reader.mjs";
+import {SEARCH_PARAMS_WRITER} from "../../lib/search-params-writer.mjs";
+
+describe("kryo-search-params | LiteralUnion", function () {
+  describe("\"foo\" | \"bar\" | \"baz\"", function () {
+    const $Ucs2String: Ucs2StringType = new Ucs2StringType({maxLength: 10});
+    type VarName = "foo" | "bar" | "baz";
+    const $VarName: LiteralUnionType<VarName> = new LiteralUnionType<VarName>({
+      type: $Ucs2String,
+      values: ["foo", "bar", "baz"],
+    });
+
+    const items: TestItem[] = [
+      {
+        value: "foo",
+        io: [
+          {writer: SEARCH_PARAMS_WRITER, reader: SEARCH_PARAMS_READER, raw: "_=foo"},
+        ],
+      },
+      {
+        value: "bar",
+        io: [
+          {writer: SEARCH_PARAMS_WRITER, reader: SEARCH_PARAMS_READER, raw: "_=bar"},
+        ],
+      },
+      {
+        value: "baz",
+        io: [
+          {writer: SEARCH_PARAMS_WRITER, reader: SEARCH_PARAMS_READER, raw: "_=baz"},
+        ],
+      },
+    ];
+
+    registerMochaSuites($VarName, items);
+
+    describe("Reader", function () {
+      const invalids: string[] = [
+        "null",
+        "true",
+        "false",
+        "",
+        "0",
+        "1",
+        "0.5",
+        "0.0001",
+        "2.220446049250313e-16",
+        "9007199254740991",
+        "-9007199254740991",
+        "\"\"",
+        "\"0\"",
+        "\"1\"",
+        "\"null\"",
+        "\"true\"",
+        "\"false\"",
+        "\"undefined\"",
+        "\"NaN\"",
+        "\"Infinity\"",
+        "\"-Infinity\"",
+        "\"quz\"",
+        "\" foo\"",
+        "\" foo \"",
+        "\"foo \"",
+        "\"FOO\"",
+        "[]",
+        "{}",
+        "\"1970-01-01T00:00:00.000Z\"",
+      ];
+      registerErrMochaTests(SEARCH_PARAMS_READER, $VarName, invalids);
+    });
+  });
+});

--- a/packages/kryo-search-params/src/test/types/literal.spec.mts
+++ b/packages/kryo-search-params/src/test/types/literal.spec.mts
@@ -1,0 +1,123 @@
+import { LiteralIoType, LiteralType } from "kryo/literal";
+import { TsEnumType } from "kryo/ts-enum";
+import { Ucs2StringType } from "kryo/ucs2-string";
+import { registerErrMochaTests, registerMochaSuites, TestItem } from "kryo-testing";
+
+import {SEARCH_PARAMS_READER} from "../../lib/search-params-reader.mjs";
+import {SEARCH_PARAMS_WRITER} from "../../lib/search-params-writer.mjs";
+
+describe("kryo-search-params | Literal", function () {
+  describe("Literal<\"foo\">", function () {
+    const $FooLit: LiteralIoType<"foo"> = new LiteralType<"foo">(() => ({
+      type: new Ucs2StringType({maxLength: Infinity}),
+      value: "foo",
+    }));
+
+    const items: TestItem[] = [
+      {
+        value: "foo",
+        io: [
+          {writer: SEARCH_PARAMS_WRITER, reader: SEARCH_PARAMS_READER, raw: "_=foo"},
+        ],
+      },
+    ];
+
+    registerMochaSuites($FooLit, items);
+
+    describe("Reader", function () {
+      const invalids: string[] = [
+        "null",
+        "true",
+        "false",
+        "",
+        "0",
+        "1",
+        "0.5",
+        "0.0001",
+        "2.220446049250313e-16",
+        "9007199254740992", // Number.MAX_SAFE_INTEGER + 1
+        "-9007199254740993", // Number.MIN_SAFE_INTEGER - 2
+        "\"\"",
+        "\"0\"",
+        "\"1\"",
+        "\"null\"",
+        "\"true\"",
+        "\"false\"",
+        "\"undefined\"",
+        "\"NaN\"",
+        "\"Infinity\"",
+        "\"-Infinity\"",
+        "\"bar\"",
+        "[]",
+        "{}",
+        "\"1970-01-01T00:00:00.000Z\"",
+      ];
+      registerErrMochaTests(SEARCH_PARAMS_READER, $FooLit, invalids);
+    });
+  });
+
+  describe("Literal<Color.Red>", function () {
+    enum Color {
+      Red,
+      Green,
+      Blue,
+    }
+
+    const $ColorRed: LiteralIoType<Color.Red> = new LiteralType<Color.Red>({
+      type: new TsEnumType({enum: Color}),
+      value: Color.Red,
+    });
+
+    const items: TestItem[] = [
+      {
+        name: "Color.Red",
+        value: Color.Red,
+        io: [
+          {writer: SEARCH_PARAMS_WRITER, reader: SEARCH_PARAMS_READER, raw: "_=Red"},
+        ],
+      },
+      {
+        name: "0",
+        value: 0,
+        io: [
+          {writer: SEARCH_PARAMS_WRITER, reader: SEARCH_PARAMS_READER, raw: "_=Red"},
+        ],
+      },
+    ];
+
+    registerMochaSuites($ColorRed, items);
+
+    describe("Reader", function () {
+      const invalids: string[] = [
+        "Green",
+        "\"Green\"",
+        "true",
+        "false",
+        "undefined",
+        "",
+        "0",
+        "1",
+        "0.5",
+        "0.0001",
+        "2.220446049250313e-16",
+        "9007199254740992", // Number.MAX_SAFE_INTEGER + 1
+        "-9007199254740993", // Number.MIN_SAFE_INTEGER - 2
+        "\"\"",
+        "\"0\"",
+        "\"1\"",
+        "\"null\"",
+        "\"true\"",
+        "\"false\"",
+        "\"undefined\"",
+        "\"NaN\"",
+        "\"Infinity\"",
+        "\"-Infinity\"",
+        "\"bar\"",
+        "[]",
+        "{}",
+        "\"1970-01-01T00:00:00.000Z\"",
+      ];
+      registerErrMochaTests(SEARCH_PARAMS_READER, $ColorRed, invalids);
+    });
+  });
+});

--- a/packages/kryo-search-params/src/test/types/map.spec.mts
+++ b/packages/kryo-search-params/src/test/types/map.spec.mts
@@ -1,0 +1,110 @@
+import { IntegerType } from "kryo/integer";
+import { MapType } from "kryo/map";
+import { Ucs2StringType } from "kryo/ucs2-string";
+import { registerErrMochaTests, registerMochaSuites, TestItem } from "kryo-testing";
+
+import {SEARCH_PARAMS_READER} from "../../lib/search-params-reader.mjs";
+import {SEARCH_PARAMS_WRITER} from "../../lib/search-params-writer.mjs";
+
+describe("kryo-search-params | Map", function () {
+  describe("IntMap", function () {
+    const $IntMap: MapType<number, number> = new MapType({
+      keyType: new IntegerType(),
+      valueType: new IntegerType(),
+      maxSize: 5,
+    });
+
+    const items: TestItem[] = [
+      {
+        value: new Map([[1, 100], [2, 200]]),
+        io: [
+          {writer: SEARCH_PARAMS_WRITER, reader: SEARCH_PARAMS_READER, raw: "1=100&2=200"},
+        ],
+      },
+    ];
+
+    registerMochaSuites($IntMap, items);
+
+    describe("Reader", function () {
+      const invalids: string[] = [
+        "null",
+        "true",
+        "false",
+        "",
+        "0",
+        "1",
+        "0.5",
+        "0.0001",
+        "2.220446049250313e-16",
+        "9007199254740991",
+        "-9007199254740991",
+        "\"\"",
+        "\"0\"",
+        "\"1\"",
+        "\"null\"",
+        "\"true\"",
+        "\"false\"",
+        "\"undefined\"",
+        "\"NaN\"",
+        "\"Infinity\"",
+        "\"-Infinity\"",
+        "\"foo\"",
+        "[]",
+        "{}",
+        "\"1970-01-01T00:00:00.000Z\"",
+      ];
+      registerErrMochaTests(SEARCH_PARAMS_READER, $IntMap, invalids);
+    });
+  });
+
+  describe("StringMap", function () {
+    const $StringMap: MapType<string, number> = new MapType({
+      keyType: new Ucs2StringType({pattern: /^a+$/, maxLength: 10}),
+      valueType: new IntegerType(),
+      maxSize: 5,
+      assumeStringKey: true,
+    });
+
+    const items: TestItem[] = [
+      {
+        value: new Map([["a", 100], ["aa", 200]]),
+        io: [
+          {writer: SEARCH_PARAMS_WRITER, reader: SEARCH_PARAMS_READER, raw: "a=100&aa=200"},
+        ],
+      },
+    ];
+
+    registerMochaSuites($StringMap, items);
+
+    describe("Reader", function () {
+      const invalids: string[] = [
+        "null",
+        "true",
+        "false",
+        "",
+        "0",
+        "1",
+        "0.5",
+        "0.0001",
+        "2.220446049250313e-16",
+        "9007199254740991",
+        "-9007199254740991",
+        "\"\"",
+        "\"0\"",
+        "\"1\"",
+        "\"null\"",
+        "\"true\"",
+        "\"false\"",
+        "\"undefined\"",
+        "\"NaN\"",
+        "\"Infinity\"",
+        "\"-Infinity\"",
+        "\"foo\"",
+        "[]",
+        "{}",
+        "\"1970-01-01T00:00:00.000Z\"",
+      ];
+      registerErrMochaTests(SEARCH_PARAMS_READER, $StringMap, invalids);
+    });
+  });
+});

--- a/packages/kryo-search-params/src/test/types/record.spec.mts
+++ b/packages/kryo-search-params/src/test/types/record.spec.mts
@@ -1,0 +1,131 @@
+import { CaseStyle } from "kryo";
+import { DateType } from "kryo/date";
+import { IntegerType } from "kryo/integer";
+import { RecordIoType, RecordType } from "kryo/record";
+import {registerErrMochaTests, registerMochaSuites, TestItem} from "kryo-testing";
+
+import {SEARCH_PARAMS_READER} from "../../lib/search-params-reader.mjs";
+import {SEARCH_PARAMS_WRITER} from "../../lib/search-params-writer.mjs";
+
+describe("kryo-search-params | Record", function () {
+  describe("TestRecord", function () {
+    const $TestRecord: RecordIoType<any> = new RecordType({
+      noExtraKeys: false,
+      properties: {
+        dateProp: {
+          optional: false,
+          type: new DateType(),
+        },
+        optIntProp: {
+          optional: true,
+          type: new IntegerType(),
+        },
+        nestedDoc: {
+          optional: true,
+          type: new RecordType({
+            noExtraKeys: false,
+            properties: {
+              id: {
+                optional: true,
+                type: new IntegerType(),
+              },
+            },
+          }),
+        },
+      },
+    });
+
+    const items: TestItem[] = [
+      {
+        value: {
+          dateProp: new Date(0),
+          optIntProp: 50,
+          nestedDoc: {
+            id: 10,
+          },
+        },
+        io: [
+          {
+            writer: SEARCH_PARAMS_WRITER,
+            reader: SEARCH_PARAMS_READER,
+            raw: "dateProp=1970-01-01T00%3A00%3A00.000Z&optIntProp=50&nestedDoc=%7B%22id%22%3A10%7D"
+          },
+          {reader: SEARCH_PARAMS_READER, raw: "dateProp=1970-01-01T00%3A00%3A00.000Z&optIntProp=50&nestedDoc=\{\"id\":10\}"},
+        ],
+      },
+      {
+        value: {
+          dateProp: new Date(0),
+          nestedDoc: {
+            id: 10,
+          },
+        },
+        io: [
+          {writer: SEARCH_PARAMS_WRITER, reader: SEARCH_PARAMS_READER, raw: "dateProp=1970-01-01T00%3A00%3A00.000Z&nestedDoc=%7B%22id%22%3A10%7D"},
+          {reader: SEARCH_PARAMS_READER, raw: "dateProp=1970-01-01T00%3A00%3A00.000Z&nestedDoc=\{\"id\":10\}"},
+        ],
+      },
+    ];
+
+    registerMochaSuites($TestRecord, items);
+
+    describe("Reader", function () {
+      const invalids: string[] = [
+        "\"1970-01-01T00:00:00.000Z\"",
+        "null",
+        "0",
+        "1",
+        "\"\"",
+        "\"0\"",
+        "\"true\"",
+        "\"false\"",
+        "true",
+        "false",
+        "[]",
+        "{}",
+      ];
+      registerErrMochaTests(SEARCH_PARAMS_READER, $TestRecord, invalids);
+    });
+  });
+
+  describe("Record: rename", function () {
+    interface Rect {
+      xMin: number;
+      xMax: number;
+      yMin: number;
+      yMax: number;
+    }
+
+    const type: RecordIoType<Rect> = new RecordType<Rect>({
+      properties: {
+        xMin: {type: new IntegerType()},
+        xMax: {type: new IntegerType(), changeCase: CaseStyle.ScreamingSnakeCase},
+        yMin: {type: new IntegerType(), rename: "__yMin"},
+        yMax: {type: new IntegerType()},
+      },
+      rename: {xMin: "xmin"},
+      changeCase: CaseStyle.KebabCase,
+    });
+
+    const items: TestItem[] = [
+      {
+        name: "Rect {xMin: 0, xMax: 10, yMin: 20, yMax: 30}",
+        value: {
+          xMin: 0,
+          xMax: 10,
+          yMin: 20,
+          yMax: 30,
+        },
+        io: [
+          {
+            writer: SEARCH_PARAMS_WRITER,
+            reader: SEARCH_PARAMS_READER,
+            raw: "xmin=0&X_MAX=10&__yMin=20&y-max=30",
+          },
+        ],
+      },
+    ];
+
+    registerMochaSuites(type, items);
+  });
+});

--- a/packages/kryo-search-params/src/test/types/tagged-union.spec.mts
+++ b/packages/kryo-search-params/src/test/types/tagged-union.spec.mts
@@ -1,0 +1,127 @@
+import { CaseStyle } from "kryo";
+import { IntegerType } from "kryo/integer";
+import { LiteralType } from "kryo/literal";
+import { RecordType } from "kryo/record";
+import { TaggedUnionType } from "kryo/tagged-union";
+import { TsEnumType } from "kryo/ts-enum";
+import { registerErrMochaTests, registerMochaSuites, TestItem } from "kryo-testing";
+
+import {SEARCH_PARAMS_READER} from "../../lib/search-params-reader.mjs";
+import {SEARCH_PARAMS_WRITER} from "../../lib/search-params-writer.mjs";
+
+describe("kryo-search-params | TaggedUnion", function () {
+  describe("Shape", function () {
+    enum ShapeType {
+      Rectangle,
+      Circle,
+    }
+
+    const shapeTypeType: TsEnumType<ShapeType> = new TsEnumType({
+      enum: ShapeType,
+      changeCase: CaseStyle.KebabCase,
+    });
+
+    interface Rectangle {
+      type: ShapeType.Rectangle;
+      width: number;
+      height: number;
+    }
+
+    const rectangleType: RecordType<Rectangle> = new RecordType<Rectangle>({
+      properties: {
+        type: {
+          type: new LiteralType<ShapeType.Rectangle>({
+            type: shapeTypeType,
+            value: ShapeType.Rectangle,
+          }),
+        },
+        width: {type: new IntegerType()},
+        height: {type: new IntegerType()},
+      },
+    });
+
+    interface Circle {
+      type: ShapeType.Circle;
+      radius: number;
+    }
+
+    const circleType: RecordType<Circle> = new RecordType<Circle>({
+      properties: {
+        type: {
+          type: new LiteralType<ShapeType.Circle>({
+            type: shapeTypeType,
+            value: ShapeType.Circle,
+          }),
+        },
+        radius: {type: new IntegerType()},
+      },
+    });
+
+    type Shape = Rectangle | Circle;
+
+    const $Shape: TaggedUnionType<Shape> = new TaggedUnionType<Shape>(() => ({
+      variants: [rectangleType, circleType],
+      tag: "type",
+    }));
+
+    const items: TestItem[] = [
+      {
+        name: "Rectangle {type: ShapeType.Rectangle, width: 10, height: 20}",
+        value: {
+          type: ShapeType.Rectangle,
+          width: 10,
+          height: 20,
+        },
+        io: [
+          {writer: SEARCH_PARAMS_WRITER, reader: SEARCH_PARAMS_READER, raw: "type=rectangle&width=10&height=20"},
+        ],
+      },
+      {
+        name: "Circle {type: ShapeType.Circle, radius: 15}",
+        value: {
+          type: ShapeType.Circle,
+          radius: 15,
+        },
+        io: [
+          {writer: SEARCH_PARAMS_WRITER, reader: SEARCH_PARAMS_READER, raw: "type=circle&radius=15"},
+        ],
+      },
+    ];
+
+    registerMochaSuites($Shape, items);
+
+    describe("Reader", function () {
+      const invalids: string[] = [
+        "{\"type\":\"circle\"}",
+        "{\"radius\":15}",
+        "{\"type\":\"circle\",\"radius\":true}",
+        "null",
+        "true",
+        "false",
+        "",
+        "0",
+        "1",
+        "0.5",
+        "0.0001",
+        "2.220446049250313e-16",
+        "9007199254740991",
+        "-9007199254740991",
+        "\"\"",
+        "\"0\"",
+        "\"1\"",
+        "\"null\"",
+        "\"true\"",
+        "\"false\"",
+        "\"undefined\"",
+        "\"NaN\"",
+        "\"Infinity\"",
+        "\"-Infinity\"",
+        "\"foo\"",
+        "[]",
+        "{}",
+        "\"1970-01-01T00:00:00.000Z\"",
+      ];
+      registerErrMochaTests(SEARCH_PARAMS_READER, $Shape, invalids);
+    });
+  });
+});

--- a/packages/kryo-search-params/src/test/types/try-union.spec.mts
+++ b/packages/kryo-search-params/src/test/types/try-union.spec.mts
@@ -1,0 +1,98 @@
+import { CaseStyle } from "kryo";
+import { IntegerType } from "kryo/integer";
+import { RecordType } from "kryo/record";
+import { TryUnionType } from "kryo/try-union";
+import { registerErrMochaTests, registerMochaSuites, TestItem } from "kryo-testing";
+
+import {SEARCH_PARAMS_READER} from "../../lib/search-params-reader.mjs";
+import {SEARCH_PARAMS_WRITER} from "../../lib/search-params-writer.mjs";
+
+describe("kryo-search-params | TryUnion", function () {
+  describe("Shape", function () {
+    interface Rectangle {
+      width: number;
+      height: number;
+    }
+
+    const $Rectangle: RecordType<Rectangle> = new RecordType<Rectangle>({
+      properties: {
+        width: {type: new IntegerType()},
+        height: {type: new IntegerType()},
+      },
+      changeCase: CaseStyle.KebabCase,
+    });
+
+    interface Circle {
+      radius: number;
+    }
+
+    const $Circle: RecordType<Circle> = new RecordType<Circle>({
+      properties: {
+        radius: {type: new IntegerType()},
+      },
+      changeCase: CaseStyle.KebabCase,
+    });
+
+    type Shape = Rectangle | Circle;
+    const $Shape: TryUnionType<Shape> = new TryUnionType<Shape>({
+      variants: [$Rectangle, $Circle],
+    });
+
+    const items: TestItem[] = [
+      {
+        name: "Rectangle {width: 10, height: 20}",
+        value: {
+          width: 10,
+          height: 20,
+        },
+        io: [
+          {writer: SEARCH_PARAMS_WRITER, reader: SEARCH_PARAMS_READER, raw: "width=10&height=20"},
+        ],
+      },
+      {
+        name: "Circle {radius: 15}",
+        value: {
+          radius: 15,
+        },
+        io: [
+          {writer: SEARCH_PARAMS_WRITER, reader: SEARCH_PARAMS_READER, raw: "radius=15"},
+        ],
+      },
+    ];
+
+    registerMochaSuites($Shape, items);
+
+    describe("Reader", function () {
+      const invalids: string[] = [
+        "{\"type\":\"circle\"}",
+        "{\"type\":\"circle\",\"radius\":true}",
+        "null",
+        "true",
+        "false",
+        "",
+        "0",
+        "1",
+        "0.5",
+        "0.0001",
+        "2.220446049250313e-16",
+        "9007199254740991",
+        "-9007199254740991",
+        "\"\"",
+        "\"0\"",
+        "\"1\"",
+        "\"null\"",
+        "\"true\"",
+        "\"false\"",
+        "\"undefined\"",
+        "\"NaN\"",
+        "\"Infinity\"",
+        "\"-Infinity\"",
+        "\"foo\"",
+        "[]",
+        "{}",
+        "\"1970-01-01T00:00:00.000Z\"",
+      ];
+      registerErrMochaTests(SEARCH_PARAMS_READER, $Shape, invalids);
+    });
+  });
+});

--- a/packages/kryo-search-params/src/test/types/ts-enum.spec.mts
+++ b/packages/kryo-search-params/src/test/types/ts-enum.spec.mts
@@ -1,0 +1,183 @@
+import { CaseStyle } from "kryo";
+import { TsEnumType } from "kryo/ts-enum";
+import { registerErrMochaTests, registerMochaSuites, TestItem } from "kryo-testing";
+
+import {SEARCH_PARAMS_READER} from "../../lib/search-params-reader.mjs";
+import {SEARCH_PARAMS_WRITER} from "../../lib/search-params-writer.mjs";
+
+describe("kryo-search-params | TsEnum", function () {
+
+  describe("Color", function () {
+    enum Color {
+      Red,
+      Green,
+      Blue,
+    }
+
+    const $Color: TsEnumType<Color> = new TsEnumType({enum: Color});
+
+    const items: TestItem[] = [
+      {
+        name: "Color.Red",
+        value: Color.Red,
+        io: [
+          {writer: SEARCH_PARAMS_WRITER, reader: SEARCH_PARAMS_READER, raw: "_=Red"},
+        ],
+      },
+      {
+        name: "Color.Green",
+        value: Color.Green,
+        io: [
+          {writer: SEARCH_PARAMS_WRITER, reader: SEARCH_PARAMS_READER, raw: "_=Green"},
+        ],
+      },
+      {
+        name: "Color.Blue",
+        value: Color.Blue,
+        io: [
+          {writer: SEARCH_PARAMS_WRITER, reader: SEARCH_PARAMS_READER, raw: "_=Blue"},
+        ],
+      },
+      {
+        value: 0,
+        io: [
+          {writer: SEARCH_PARAMS_WRITER, reader: SEARCH_PARAMS_READER, raw: "_=Red"},
+        ],
+      },
+      {
+        value: 1,
+        io: [
+          {writer: SEARCH_PARAMS_WRITER, reader: SEARCH_PARAMS_READER, raw: "_=Green"},
+        ],
+      },
+      {
+        value: 2,
+        io: [
+          {writer: SEARCH_PARAMS_WRITER, reader: SEARCH_PARAMS_READER, raw: "_=Blue"},
+        ],
+      },
+    ];
+
+    registerMochaSuites($Color, items);
+
+    describe("Reader", function () {
+      const invalids: string[] = [
+        "{\"type\":\"circle\"}",
+        "{\"type\":\"circle\",\"radius\":true}",
+        "null",
+        "true",
+        "false",
+        "",
+        "0",
+        "1",
+        "0.5",
+        "0.0001",
+        "2.220446049250313e-16",
+        "9007199254740991",
+        "-9007199254740991",
+        "\"\"",
+        "\"0\"",
+        "\"1\"",
+        "\"null\"",
+        "\"true\"",
+        "\"false\"",
+        "\"undefined\"",
+        "\"NaN\"",
+        "\"Infinity\"",
+        "\"-Infinity\"",
+        "\"foo\"",
+        "[]",
+        "{}",
+        "\"1970-01-01T00:00:00.000Z\"",
+      ];
+      registerErrMochaTests(SEARCH_PARAMS_READER, $Color, invalids);
+    });
+  });
+
+  describe("Node (Kebab-Case)", function () {
+    enum Node {
+      Expression,
+      BinaryOperator,
+      BlockStatement,
+    }
+
+    const $Node: TsEnumType<Node> = new TsEnumType(() => ({enum: Node, changeCase: CaseStyle.KebabCase}));
+
+    const items: TestItem[] = [
+      {
+        name: "Node.Expression",
+        value: Node.Expression,
+        io: [
+          {writer: SEARCH_PARAMS_WRITER, reader: SEARCH_PARAMS_READER, raw: "_=expression"},
+        ],
+      },
+      {
+        name: "Node.BinaryOperator",
+        value: Node.BinaryOperator,
+        io: [
+          {writer: SEARCH_PARAMS_WRITER, reader: SEARCH_PARAMS_READER, raw: "_=binary-operator"},
+        ],
+      },
+      {
+        name: "Node.BlockStatement",
+        value: Node.BlockStatement,
+        io: [
+          {writer: SEARCH_PARAMS_WRITER, reader: SEARCH_PARAMS_READER, raw: "_=block-statement"},
+        ],
+      },
+      {
+        value: 0,
+        io: [
+          {writer: SEARCH_PARAMS_WRITER, reader: SEARCH_PARAMS_READER, raw: "_=expression"},
+        ],
+      },
+      {
+        value: 1,
+        io: [
+          {writer: SEARCH_PARAMS_WRITER, reader: SEARCH_PARAMS_READER, raw: "_=binary-operator"},
+        ],
+      },
+      {
+        value: 2,
+        io: [
+          {writer: SEARCH_PARAMS_WRITER, reader: SEARCH_PARAMS_READER, raw: "_=block-statement"},
+        ],
+      },
+    ];
+
+    registerMochaSuites($Node, items);
+
+    describe("Reader", function () {
+      const invalids: string[] = [
+        "{\"type\":\"circle\"}",
+        "{\"type\":\"circle\",\"radius\":true}",
+        "null",
+        "true",
+        "false",
+        "",
+        "0",
+        "1",
+        "0.5",
+        "0.0001",
+        "2.220446049250313e-16",
+        "9007199254740991",
+        "-9007199254740991",
+        "\"\"",
+        "\"0\"",
+        "\"1\"",
+        "\"null\"",
+        "\"true\"",
+        "\"false\"",
+        "\"undefined\"",
+        "\"NaN\"",
+        "\"Infinity\"",
+        "\"-Infinity\"",
+        "\"foo\"",
+        "[]",
+        "{}",
+        "\"1970-01-01T00:00:00.000Z\"",
+      ];
+      registerErrMochaTests(SEARCH_PARAMS_READER, $Node, invalids);
+    });
+  });
+});

--- a/packages/kryo-search-params/src/test/types/ucs2-string.spec.mts
+++ b/packages/kryo-search-params/src/test/types/ucs2-string.spec.mts
@@ -1,0 +1,67 @@
+import { Ucs2StringType } from "kryo/ucs2-string";
+import { registerErrMochaTests, registerMochaSuites, TestItem } from "kryo-testing";
+
+import {SEARCH_PARAMS_READER} from "../../lib/search-params-reader.mjs";
+import {SEARCH_PARAMS_WRITER} from "../../lib/search-params-writer.mjs";
+
+describe("kryo-search-params | Ucs2StringType", function () {
+  describe("Ucs2StringType({maxLength: 15})", function () {
+    const $String50: Ucs2StringType = new Ucs2StringType({maxLength: 15});
+
+    const items: TestItem[] = [
+      {
+        value: "",
+        io: [
+          {writer: SEARCH_PARAMS_WRITER, reader: SEARCH_PARAMS_READER, raw: "_="},
+        ],
+      },
+      {
+        value: "Hello World!",
+        io: [
+          {writer: SEARCH_PARAMS_WRITER, reader: SEARCH_PARAMS_READER, raw: "_=Hello+World%21"},
+          {reader: SEARCH_PARAMS_READER, raw: "_=Hello World!"},
+        ],
+      },
+      {
+        value: "ԂЯØǷ Łƕ੬ ɃɅϨϞ",
+        io: [
+          {writer: SEARCH_PARAMS_WRITER, reader: SEARCH_PARAMS_READER, raw: "_=%D4%82%D0%AF%C3%98%C7%B7+%C5%81%C6%95%E0%A9%AC+%C9%83%C9%85%CF%A8%CF%9E"},
+          {reader: SEARCH_PARAMS_READER, raw: "_=ԂЯØǷ Łƕ੬ ɃɅϨϞ"},
+        ],
+      },
+    ];
+
+    registerMochaSuites($String50, items);
+
+    describe("Reader", function () {
+      const invalids: string[] = [
+        "null",
+        "true",
+        "false",
+        "",
+        "0",
+        "1",
+        "0.5",
+        "0.0001",
+        "2.220446049250313e-16",
+        "9007199254740991",
+        "-9007199254740991",
+        "\"\"",
+        "\"0\"",
+        "\"1\"",
+        "\"null\"",
+        "\"true\"",
+        "\"false\"",
+        "\"undefined\"",
+        "\"NaN\"",
+        "\"Infinity\"",
+        "\"-Infinity\"",
+        "\"foo\"",
+        "[]",
+        "{}",
+        "\"1970-01-01T00:00:00.000Z\"",
+      ];
+      registerErrMochaTests(SEARCH_PARAMS_READER, $String50, invalids);
+    });
+  });
+});

--- a/packages/kryo-search-params/src/test/types/usv-string.spec.mts
+++ b/packages/kryo-search-params/src/test/types/usv-string.spec.mts
@@ -1,0 +1,56 @@
+import { UsvStringType } from "kryo/usv-string";
+import { registerErrMochaTests, registerMochaSuites, TestItem } from "kryo-testing";
+
+import {SEARCH_PARAMS_READER} from "../../lib/search-params-reader.mjs";
+import {SEARCH_PARAMS_WRITER} from "../../lib/search-params-writer.mjs";
+
+describe("kryo-search-params | UsvString", function () {
+  const type: UsvStringType = new UsvStringType({maxCodepoints: 500});
+
+  const items: TestItem[] = [
+    {
+      value: "",
+      io: [
+        {writer: SEARCH_PARAMS_WRITER, reader: SEARCH_PARAMS_READER, raw: "_="},
+      ],
+    },
+    {
+      value: "Hello World!",
+      io: [
+        {writer: SEARCH_PARAMS_WRITER, reader: SEARCH_PARAMS_READER, raw: "_=Hello+World%21"},
+        {reader: SEARCH_PARAMS_READER, raw: "_=Hello World!"},
+      ],
+    },
+    {
+      value: "ԂЯØǷ Łƕ੬ ɃɅϨϞ",
+      io: [
+        {writer: SEARCH_PARAMS_WRITER, reader: SEARCH_PARAMS_READER, raw: "_=%D4%82%D0%AF%C3%98%C7%B7+%C5%81%C6%95%E0%A9%AC+%C9%83%C9%85%CF%A8%CF%9E"},
+        {reader: SEARCH_PARAMS_READER, raw: "_=ԂЯØǷ Łƕ੬ ɃɅϨϞ"},
+      ],
+    },
+    {
+      value: "1970-01-01T00:00:00.000Z",
+      io: [
+        {writer: SEARCH_PARAMS_WRITER, reader: SEARCH_PARAMS_READER, raw: "_=1970-01-01T00%3A00%3A00.000Z"},
+        {reader: SEARCH_PARAMS_READER, raw: "_=1970-01-01T00:00:00.000Z"},
+      ],
+    },
+  ];
+
+  registerMochaSuites(type, items);
+
+  describe("Reader", function () {
+    const invalids: string[] = [
+      "0.5",
+      "0.0001",
+      "null",
+      "true",
+      "false",
+      "[]",
+      "{}",
+      "",
+      "\"\udd1e\ud834\"",
+    ];
+    registerErrMochaTests(SEARCH_PARAMS_READER, type, invalids);
+  });
+});

--- a/packages/kryo/src/lib/checks/check-kind.mts
+++ b/packages/kryo/src/lib/checks/check-kind.mts
@@ -9,6 +9,7 @@ export enum CheckKind {
   LiteralValue,
   LowerCase,
   PropertyKey,
+  PropertyKeyFormat,
   PropertyValue,
   Range,
   StringPattern,

--- a/packages/kryo/src/lib/checks/index.mts
+++ b/packages/kryo/src/lib/checks/index.mts
@@ -18,6 +18,7 @@ import {formatUnionMatchCheck, UnionMatchCheck} from "./union-match.mjs";
 import {formatUnionTagPresentCheck, UnionTagPresentCheck} from "./union-tag-present.mjs";
 import {formatUnionTagValueCheck, UnionTagValueCheck} from "./union-tag-value.mjs";
 import {formatUnixTimestampCheck, UnixTimestampCheck} from "./unix-timestamp.mjs";
+import {formatPropertyKeyFormatCheck, PropertyKeyFormatCheck} from "./property-key-format.mjs";
 
 export type Check =
   AggregateCheck
@@ -29,6 +30,7 @@ export type Check =
   | LiteralValueCheck
   | LowerCaseCheck
   | PropertyKeyCheck
+  | PropertyKeyFormatCheck
   | PropertyValueCheck
   | RangeCheck
   | SizeCheck
@@ -52,6 +54,7 @@ export function format(check: Check) {
     case CheckKind.LiteralValue: return formatLiteralValueCheck();
     case CheckKind.LowerCase: return formatLowerCaseCheck();
     case CheckKind.PropertyKey: return formatPropertyKeyCheck();
+    case CheckKind.PropertyKeyFormat: return formatPropertyKeyFormatCheck();
     case CheckKind.PropertyValue: return formatPropertyValueCheck();
     case CheckKind.Range: return formatRangeCheck(check);
     case CheckKind.Size: return formatSizeCheck(check);

--- a/packages/kryo/src/lib/checks/property-key-format.mts
+++ b/packages/kryo/src/lib/checks/property-key-format.mts
@@ -1,0 +1,11 @@
+import {CheckKind} from "./check-kind.mjs";
+import {CheckId} from "../index.mjs";
+
+export interface PropertyKeyFormatCheck {
+  readonly check: CheckKind.PropertyKeyFormat,
+  readonly children?: readonly CheckId[];
+}
+
+export function formatPropertyKeyFormatCheck(): string {
+  return `record property key must be valid`;
+}

--- a/packages/kryo/src/lib/checks/property-key.mts
+++ b/packages/kryo/src/lib/checks/property-key.mts
@@ -6,5 +6,5 @@ export interface PropertyKeyCheck {
 }
 
 export function formatPropertyKeyCheck(): string {
-  return "record property key must be present";
+  return `record property key must be valid`;
 }

--- a/packages/kryo/src/lib/tagged-union.mts
+++ b/packages/kryo/src/lib/tagged-union.mts
@@ -128,7 +128,7 @@ implements IoType<T>,
             readVisitor({fromString: (value: string): Result<string, CheckId> => ({ok: true, value})}),
           );
           if (!okUnecheckedKey) {
-            return writeError(cx, {check: CheckKind.PropertyKey});
+            return writeError(cx, {check: CheckKind.PropertyKeyFormat, children: [outKey]});
           }
           if (outKey !== outTag) {
             continue;

--- a/test.tsconfig.json
+++ b/test.tsconfig.json
@@ -16,6 +16,9 @@
     },
     {
       "path": "./packages/kryo-qs/src/test"
+    },
+    {
+      "path": "./packages/kryo-search-params/src/test"
     }
   ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -149,15 +149,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/bson@npm:^4.2.0":
-  version: 4.2.0
-  resolution: "@types/bson@npm:4.2.0"
-  dependencies:
-    bson: "npm:*"
-  checksum: 55abf60c57b7f05655c210b386392636a299a7df18b89cec2cde0aa87374d97dd4ac9632226b0f6fe135d16ad4296ae5ddc782f6e9132d38c53dd26a6df8e704
-  languageName: node
-  linkType: hard
-
 "@types/chai@npm:^4.3.1, @types/chai@npm:^4.3.11":
   version: 4.3.11
   resolution: "@types/chai@npm:4.3.11"
@@ -217,14 +208,14 @@ __metadata:
   linkType: hard
 
 "@typescript-eslint/eslint-plugin@npm:^6.19.0":
-  version: 6.19.0
-  resolution: "@typescript-eslint/eslint-plugin@npm:6.19.0"
+  version: 6.19.1
+  resolution: "@typescript-eslint/eslint-plugin@npm:6.19.1"
   dependencies:
     "@eslint-community/regexpp": "npm:^4.5.1"
-    "@typescript-eslint/scope-manager": "npm:6.19.0"
-    "@typescript-eslint/type-utils": "npm:6.19.0"
-    "@typescript-eslint/utils": "npm:6.19.0"
-    "@typescript-eslint/visitor-keys": "npm:6.19.0"
+    "@typescript-eslint/scope-manager": "npm:6.19.1"
+    "@typescript-eslint/type-utils": "npm:6.19.1"
+    "@typescript-eslint/utils": "npm:6.19.1"
+    "@typescript-eslint/visitor-keys": "npm:6.19.1"
     debug: "npm:^4.3.4"
     graphemer: "npm:^1.4.0"
     ignore: "npm:^5.2.4"
@@ -237,44 +228,44 @@ __metadata:
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: 5ed8483d792c4bc6ed697159c84a47ba5c35cd124949883813f2053b972537de3900a7ae26d4d6f370194f2cc7929baa2d09268e0b90118f20ed961cf6c176b9
+  checksum: e88a35527b066a42d0253d153183a360faedc1cd39867c541ce7cb1f7b22f8446bb913b998fcdeba269d5d4217888af42e6d64da5c0592b1f49ed5648d2e3e84
   languageName: node
   linkType: hard
 
 "@typescript-eslint/parser@npm:^6.19.0":
-  version: 6.19.0
-  resolution: "@typescript-eslint/parser@npm:6.19.0"
+  version: 6.19.1
+  resolution: "@typescript-eslint/parser@npm:6.19.1"
   dependencies:
-    "@typescript-eslint/scope-manager": "npm:6.19.0"
-    "@typescript-eslint/types": "npm:6.19.0"
-    "@typescript-eslint/typescript-estree": "npm:6.19.0"
-    "@typescript-eslint/visitor-keys": "npm:6.19.0"
+    "@typescript-eslint/scope-manager": "npm:6.19.1"
+    "@typescript-eslint/types": "npm:6.19.1"
+    "@typescript-eslint/typescript-estree": "npm:6.19.1"
+    "@typescript-eslint/visitor-keys": "npm:6.19.1"
     debug: "npm:^4.3.4"
   peerDependencies:
     eslint: ^7.0.0 || ^8.0.0
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: 0c6280a69127cf521b3403be9877775eecda2b2e4e44a67874b0d9cf82ed95a7971dac2db633e55ec22f8026da2681137110b2924313421a22b7c03eba8cda67
+  checksum: 63ff00a56586879a62e40b27b55c94501173fcf2fb5a620d01e7505851b4bb20feb1e7fbad36010af97aefc0a722267d9ce3aa004abab22cb7eb23eebb0102ce
   languageName: node
   linkType: hard
 
-"@typescript-eslint/scope-manager@npm:6.19.0":
-  version: 6.19.0
-  resolution: "@typescript-eslint/scope-manager@npm:6.19.0"
+"@typescript-eslint/scope-manager@npm:6.19.1":
+  version: 6.19.1
+  resolution: "@typescript-eslint/scope-manager@npm:6.19.1"
   dependencies:
-    "@typescript-eslint/types": "npm:6.19.0"
-    "@typescript-eslint/visitor-keys": "npm:6.19.0"
-  checksum: d36c51c05e14c51ce13181120eeea46d1edd59ed1ff16dc4ec1f5532a975b5faec5c10a373aaa90545f82a12330c6cba18ecedc734e18288f5874855c48ba808
+    "@typescript-eslint/types": "npm:6.19.1"
+    "@typescript-eslint/visitor-keys": "npm:6.19.1"
+  checksum: 2a17f68d3c41582bfac7ecd192e2c2539cf4d2c9728a7018d842da7a8a23986b8a1f8cfcb59862c909b483140a2d164a4ba44451905e0a141378e5dd0df056cc
   languageName: node
   linkType: hard
 
-"@typescript-eslint/type-utils@npm:6.19.0":
-  version: 6.19.0
-  resolution: "@typescript-eslint/type-utils@npm:6.19.0"
+"@typescript-eslint/type-utils@npm:6.19.1":
+  version: 6.19.1
+  resolution: "@typescript-eslint/type-utils@npm:6.19.1"
   dependencies:
-    "@typescript-eslint/typescript-estree": "npm:6.19.0"
-    "@typescript-eslint/utils": "npm:6.19.0"
+    "@typescript-eslint/typescript-estree": "npm:6.19.1"
+    "@typescript-eslint/utils": "npm:6.19.1"
     debug: "npm:^4.3.4"
     ts-api-utils: "npm:^1.0.1"
   peerDependencies:
@@ -282,23 +273,23 @@ __metadata:
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: f1f20ac28c03dd18546050b63ec0b0fd8c67780265ccb9ef566f16441c3de5deb2607a6046fefdebe8a43ac11fecdf0b009f8e5f70a3d15916d855be74b0f3bb
+  checksum: 5150b897d8b3778c549c6b964b031981da1039dfa0fb89a0eb92702735ca55793d2f840af14b340eccbca81669ba3dd02d7f09fb420fb66b18ec9f1f211b3243
   languageName: node
   linkType: hard
 
-"@typescript-eslint/types@npm:6.19.0":
-  version: 6.19.0
-  resolution: "@typescript-eslint/types@npm:6.19.0"
-  checksum: 396ad2ad9f2d759dd87bc880a1ffc9d11fda04db8af9402abb4e8eccd58c01fa2d26e38b186526d0b457012f7c912e7afdab2a3798a73aa0ae34abaf50d617ae
+"@typescript-eslint/types@npm:6.19.1":
+  version: 6.19.1
+  resolution: "@typescript-eslint/types@npm:6.19.1"
+  checksum: 93f3ded80b81a1b8686866b93e36ddf9bac04604d09e88d7ed1ec25b6b2f49ff64747d8d194ba1f3215e231fd0790b88fb5ecadcc6ed53ff584f8c0b87423216
   languageName: node
   linkType: hard
 
-"@typescript-eslint/typescript-estree@npm:6.19.0":
-  version: 6.19.0
-  resolution: "@typescript-eslint/typescript-estree@npm:6.19.0"
+"@typescript-eslint/typescript-estree@npm:6.19.1":
+  version: 6.19.1
+  resolution: "@typescript-eslint/typescript-estree@npm:6.19.1"
   dependencies:
-    "@typescript-eslint/types": "npm:6.19.0"
-    "@typescript-eslint/visitor-keys": "npm:6.19.0"
+    "@typescript-eslint/types": "npm:6.19.1"
+    "@typescript-eslint/visitor-keys": "npm:6.19.1"
     debug: "npm:^4.3.4"
     globby: "npm:^11.1.0"
     is-glob: "npm:^4.0.3"
@@ -308,34 +299,34 @@ __metadata:
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: 06e24bb145a302299a6cf86b36652bd4d7080c4e88517ebc24bdc137c57425a68db256ba628ce16b568bfec8020ae2a748ccee93e304efeded329cb3292b17bf
+  checksum: 3ce91dd477ccb2cc3cf5d07ac8d23792988f4fad78bfd39783292846f32daea5081d3790ba9cc795d9de89ea2e1d55dc9c3d2aeaa8597093b0f6ac3a206195e9
   languageName: node
   linkType: hard
 
-"@typescript-eslint/utils@npm:6.19.0":
-  version: 6.19.0
-  resolution: "@typescript-eslint/utils@npm:6.19.0"
+"@typescript-eslint/utils@npm:6.19.1":
+  version: 6.19.1
+  resolution: "@typescript-eslint/utils@npm:6.19.1"
   dependencies:
     "@eslint-community/eslint-utils": "npm:^4.4.0"
     "@types/json-schema": "npm:^7.0.12"
     "@types/semver": "npm:^7.5.0"
-    "@typescript-eslint/scope-manager": "npm:6.19.0"
-    "@typescript-eslint/types": "npm:6.19.0"
-    "@typescript-eslint/typescript-estree": "npm:6.19.0"
+    "@typescript-eslint/scope-manager": "npm:6.19.1"
+    "@typescript-eslint/types": "npm:6.19.1"
+    "@typescript-eslint/typescript-estree": "npm:6.19.1"
     semver: "npm:^7.5.4"
   peerDependencies:
     eslint: ^7.0.0 || ^8.0.0
-  checksum: 4080c36331204ffef9f218e29f43da767f17551fa4d3877c3d3b49194f7c7382dd9ae2124e7b5ebd47d5556946bb6ad195b47d7d215553efabacdebf81b9e74d
+  checksum: f8931df675defa84af373c81bbb13cc34c2fcf0803c687a38b982e85335dbf2fb8415667fbabaa043df0326ba3e98ed974104bbd21f09ec538304fc3adeed0c3
   languageName: node
   linkType: hard
 
-"@typescript-eslint/visitor-keys@npm:6.19.0":
-  version: 6.19.0
-  resolution: "@typescript-eslint/visitor-keys@npm:6.19.0"
+"@typescript-eslint/visitor-keys@npm:6.19.1":
+  version: 6.19.1
+  resolution: "@typescript-eslint/visitor-keys@npm:6.19.1"
   dependencies:
-    "@typescript-eslint/types": "npm:6.19.0"
+    "@typescript-eslint/types": "npm:6.19.1"
     eslint-visitor-keys: "npm:^3.4.1"
-  checksum: 8d51c0b8d94c5df044fde958f62741cef55be97c6a3a16c47e4df9af7b2ff13aa1ee03ca5240777481dca53f3b7a9b00b329e50aff5e3ad829d96bc5f63ca2c3
+  checksum: b41f3247520e1e4d3e43876843b03f0d887e544d4ac8a9e1f4b25d08568da36fedde883fa226488a595f688198859cd0290d0f1351c2ca6cbc30cca2c90adf21
   languageName: node
   linkType: hard
 
@@ -526,7 +517,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bson@npm:*, bson@npm:^6.2.0":
+"bson@npm:^6.2.0":
   version: 6.2.0
   resolution: "bson@npm:6.2.0"
   checksum: 6e079d1cafabda340a34ed2f496e20770abdee96e076ff23de810b36531dc75ac41fbe9a7d4644a9fbeae3dfd32bf2973465058fcdbe8601c7783b4b42c5ba61
@@ -579,8 +570,8 @@ __metadata:
   linkType: hard
 
 "chai@npm:^4.3.6":
-  version: 4.4.0
-  resolution: "chai@npm:4.4.0"
+  version: 4.4.1
+  resolution: "chai@npm:4.4.1"
   dependencies:
     assertion-error: "npm:^1.1.0"
     check-error: "npm:^1.0.3"
@@ -589,7 +580,7 @@ __metadata:
     loupe: "npm:^2.3.6"
     pathval: "npm:^1.1.1"
     type-detect: "npm:^4.0.8"
-  checksum: c6904e4efe00f69261e9a06bce772171b7401a6e7fc07b90baef6c58c25cdd0b667cbd997512615cae7df5624cb6f5fac4f5574f87cf6e9f98ec745f3513239d
+  checksum: c6d7aba913a67529c68dbec3673f94eb9c586c5474cc5142bd0b587c9c9ec9e5fbaa937e038ecaa6475aea31433752d5fabdd033b9248bde6ae53befcde774ae
   languageName: node
   linkType: hard
 
@@ -1269,7 +1260,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"has-property-descriptors@npm:^1.0.0":
+"has-property-descriptors@npm:^1.0.0, has-property-descriptors@npm:^1.0.1":
   version: 1.0.1
   resolution: "has-property-descriptors@npm:1.0.1"
   dependencies:
@@ -1540,7 +1531,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "kryo-bson@workspace:packages/kryo-bson"
   dependencies:
-    "@types/bson": "npm:^4.2.0"
     "@types/chai": "npm:^4.3.11"
     "@types/mocha": "npm:^10.0.6"
     "@types/node": "npm:^20.11.5"
@@ -1595,6 +1585,22 @@ __metadata:
     kryo-testing: "workspace:^"
     mocha: "npm:^10.2.0"
     qs: "npm:^6.11.2"
+    typescript: "npm:^5.3.3"
+  languageName: unknown
+  linkType: soft
+
+"kryo-search-params@workspace:packages/kryo-search-params":
+  version: 0.0.0-use.local
+  resolution: "kryo-search-params@workspace:packages/kryo-search-params"
+  dependencies:
+    "@types/chai": "npm:^4.3.11"
+    "@types/mocha": "npm:^10.0.6"
+    "@types/node": "npm:^20.11.5"
+    chai: "npm:^5.0.0"
+    kryo: "workspace:^"
+    kryo-json: "workspace:^"
+    kryo-testing: "workspace:^"
+    mocha: "npm:^10.2.0"
     typescript: "npm:^5.3.3"
   languageName: unknown
   linkType: soft
@@ -2242,14 +2248,15 @@ __metadata:
   linkType: hard
 
 "set-function-length@npm:^1.1.1":
-  version: 1.1.1
-  resolution: "set-function-length@npm:1.1.1"
+  version: 1.2.0
+  resolution: "set-function-length@npm:1.2.0"
   dependencies:
     define-data-property: "npm:^1.1.1"
-    get-intrinsic: "npm:^1.2.1"
+    function-bind: "npm:^1.1.2"
+    get-intrinsic: "npm:^1.2.2"
     gopd: "npm:^1.0.1"
-    has-property-descriptors: "npm:^1.0.0"
-  checksum: 745ed1d7dc69a6185e0820082fe73838ab3dfd01e75cce83a41e4c1d68bbf34bc5fb38f32ded542ae0b557536b5d2781594499b5dcd19e7db138e06292a76c7b
+    has-property-descriptors: "npm:^1.0.1"
+  checksum: 6d609cd060c488d7d2178a5d4c3689f8a6afa26fa4c48ff4a0516664ff9b84c1c0898915777f5628092dab55c4fcead205525e2edd15c659423bf86f790fdcae
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This commit provides a new package: `kryo-search-params`. It is an alternative for `kryo-qs` where serialization uses `URLSearchParams`.